### PR TITLE
#34: Console reporter improvments

### DIFF
--- a/shakedown/frontend/shake_run.py
+++ b/shakedown/frontend/shake_run.py
@@ -5,7 +5,7 @@ from ..runner import run_tests
 from ..session import Session
 from ..utils import cli_utils
 from ..utils.interactive import start_interactive_shell
-from ..utils.reporter import Reporter
+from ..utils.reporter import report_context
 import logbook
 import sys
 
@@ -17,14 +17,14 @@ def shake_run(args, report_stream=sys.stderr):
     with cli_utils.get_cli_environment_context(argv=args, parser=parser) as args:
         test_loader = Loader()
         with Session() as session:
-            if not args.paths and not args.interactive:
-                parser.error("No tests specified")
-            if args.interactive:
-                start_interactive_shell()
-            for path in args.paths:
-                run_tests(test_loader.iter_runnable_tests(path))
+            with report_context(report_stream):
+                if not args.paths and not args.interactive:
+                    parser.error("No tests specified")
+                if args.interactive:
+                    start_interactive_shell()
+                for path in args.paths:
+                    run_tests(test_loader.iter_runnable_tests(path))
             trigger_hook.result_summary()
-        Reporter(report_stream).report_session(session)
         if session.result.is_success():
             return 0
         return -1

--- a/shakedown/result.py
+++ b/shakedown/result.py
@@ -1,4 +1,13 @@
+import traceback
+import logbook
 import sys
+from .conf import config
+
+def get_exception_info():
+    if config.root.log.console_level > logbook.NOTICE:
+        return sys.exc_info()[1]
+    else:
+        return traceback.format_exc()
 
 class Result(object):
     def __init__(self, test_metadata=None):
@@ -24,15 +33,17 @@ class Result(object):
     def mark_finished(self):
         self._finished = True
     def add_error(self):
-        self._errors.append(sys.exc_info()[1])
+        self._errors.append(get_exception_info())
     def add_failure(self):
-        self._failures.append(sys.exc_info()[1])
+        self._failures.append(get_exception_info())
     def add_skip(self, reason):
         self._skips.append(reason)
     def get_errors(self):
         return self._errors
     def get_failures(self):
         return self._failures
+    def get_skips(self):
+        return self._skips
 
 class AggregatedResult(object):
     def __init__(self, result_iterator_func):

--- a/shakedown/runner.py
+++ b/shakedown/runner.py
@@ -23,8 +23,8 @@ def run_tests(iterable):
         ensure_shakedown_metadata(test).id = context.session.id_space.allocate()
         _logger.debug("Running {0}...", test)
         with _get_test_context(test):
-            with _update_result_context() as result:
-                with _get_test_hooks_context():
+            with _get_test_hooks_context():
+                with _update_result_context() as result:
                     try:
                         with handling_exceptions():
                             test.run()
@@ -49,13 +49,12 @@ def _get_test_hooks_context():
         yield
     except SkipTest:
         hooks.test_skip()
-        raise
     except TestFailed:
         hooks.test_failure()
-        raise
     except:
         hooks.test_error()
-        raise
+    else:
+        hooks.test_success()
     finally:
         hooks.test_end()
 
@@ -82,9 +81,12 @@ def _update_result_context():
             raise
     except SkipTest as e:
         result.add_skip(e.reason)
+        raise
     except TestFailed:
         result.add_failure()
+        raise
     except:
         result.add_error()
+        raise
     finally:
         result.mark_finished()

--- a/shakedown/utils/hooks_context_manager.py
+++ b/shakedown/utils/hooks_context_manager.py
@@ -1,0 +1,23 @@
+from .. import hooks
+
+class HooksContextManager(object):
+    """
+    This class can be used to register and unregister multiple hooks
+    within a context. The callbacks are collected by searching methods
+    prefixed by "on_<hook name>" (.e.g: on_test_error).
+    """
+    PREFIX = "on_"
+    def __init__(self):
+        self._id = object()
+    def _get_hooks_and_callbacks(self):
+        return [(getattr(hooks, member.replace(self.PREFIX, "")), # the hook
+                 getattr(self, member)) # the callback
+                for member in dir(self)
+                if member.startswith(self.PREFIX)]
+    def __enter__(self):
+        for hook, callback in self._get_hooks_and_callbacks():
+            hook.register(callback, self._id)
+        return self
+    def __exit__(self, *e):
+        for hook, _ in self._get_hooks_and_callbacks():
+            hook.unregister_by_identifier(self._id)

--- a/shakedown/utils/reporter.py
+++ b/shakedown/utils/reporter.py
@@ -1,5 +1,23 @@
-from .formatter import Formatter
+import logbook
 import itertools
+from contextlib import contextmanager
+from .formatter import Formatter
+from .hooks_context_manager import HooksContextManager
+from ..conf import config
+from ..ctx import context
+
+@contextmanager
+def report_context(report_stream):
+    live_reporter_type = ConciseLiveReporter if config.root.log.console_level > logbook.NOTICE \
+                         else VerboseLiveReporter
+    with live_reporter_type(report_stream):
+        yield
+    SummaryReporter(report_stream).report_session(context.session)
+
+def _format_unsuccessfull(formatter, result):
+    with formatter.indented():
+        for x in itertools.chain(result.get_failures(), result.get_errors(), result.get_skips()):
+            formatter.writeln(x)
 
 _REPORT_COLUMNS = [
     ("Successful", "get_num_successful"),
@@ -8,9 +26,9 @@ _REPORT_COLUMNS = [
     ("Skipped", "get_num_skipped"),
     ]
 
-class Reporter(object):
+class SummaryReporter(object):
     def __init__(self, stream):
-        super(Reporter, self).__init__()
+        super(SummaryReporter, self).__init__()
         self._formatter = Formatter(stream)
     def report_session(self, session):
         self._describe_unsuccessful(session)
@@ -21,9 +39,7 @@ class Reporter(object):
             if result.is_success():
                 continue
             self._formatter.writeln("> ", result.test_metadata)
-            with self._formatter.indented():
-                for x in itertools.chain(result.get_failures(), result.get_errors()):
-                    self._formatter.writeln(x)
+            _format_unsuccessfull(self._formatter, result)
     def _describe_summary(self, session):
         self._formatter.write_separator()
         for col, _ in _REPORT_COLUMNS:
@@ -32,3 +48,36 @@ class Reporter(object):
         for col, method_name in _REPORT_COLUMNS:
             self._formatter.write(str(getattr(session.result, method_name)()).ljust(len(col)+2))
         self._formatter.writeln()
+
+class BaseLiveReporter(HooksContextManager):
+    def __init__(self, report_stream):
+        super(BaseLiveReporter, self).__init__()
+        self._formatter = Formatter(report_stream)
+
+class VerboseLiveReporter(BaseLiveReporter):
+    def on_test_start(self):
+        self._formatter.write("> ", context.test)
+        self._formatter.write(" ... ")
+    def on_test_success(self):
+        self._formatter.writeln("ok")
+    def on_test_error(self):
+        self._formatter.writeln("error")
+        _format_unsuccessfull(self._formatter, context.session.get_result(context.test))
+    def on_test_failure(self):
+        self._formatter.writeln("fail")
+        _format_unsuccessfull(self._formatter, context.session.get_result(context.test))
+    def on_test_skip(self):
+        self._formatter.writeln("skip")
+        _format_unsuccessfull(self._formatter, context.session.get_result(context.test))
+
+class ConciseLiveReporter(BaseLiveReporter):
+    def on_test_success(self):
+        self._formatter.write(".")
+    def on_test_error(self):
+        self._formatter.write("E")
+    def on_test_failure(self):
+        self._formatter.write("F")
+    def on_test_skip(self):
+        self._formatter.write("S")
+    def on_result_summary(self):
+        self._formatter.writeln("")

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,0 +1,73 @@
+import logbook
+from six.moves import cStringIO
+from .utils import TestCase
+from .utils.test_generator import TestGenerator
+from shakedown.frontend import shake_run
+
+class ShakeRunTest(TestCase):
+    def setUp(self):
+        super(ShakeRunTest, self).setUp()
+        self.generator = TestGenerator()
+        (self.success_test, self.fail_test,
+         self.error_test, self.skip_test) = self.generator.generate_tests(4)
+        self.generator.make_test_skip(self.skip_test)
+        self.generator.make_test_fail(self.fail_test)
+        self.generator.make_test_raise_exception(self.error_test)
+
+        self.root_path = self.generator.write_test_directory(
+            {
+                "success_test.py" : self.success_test,
+                "fail_test.py" : self.fail_test,
+                "error_test.py" : self.error_test,
+                "skip_test.py" : self.skip_test
+            }
+        )
+        self.report_stream = cStringIO()
+        self.separator = "-" * 80
+    def _get_output_part(self, part):
+        self.report_stream.seek(0)
+        return self.report_stream.getvalue().split(self.separator)[part]
+    def get_live_part(self):
+        return self._get_output_part(0)
+    def get_exceptions_part(self):
+        return self._get_output_part(1)
+    def get_summary_part(self):
+        return self._get_output_part(2)
+    def _shake_run(self):
+        return shake_run.shake_run([self.root_path], report_stream=self.report_stream)
+    def test_live_concise(self):
+        self.override_config("log.console_level", logbook.WARNING)
+        self._shake_run()
+        result = self.get_live_part()
+        self.assertEqual(set(result), set("EFS."))
+        self.assertEqual(len(result), 4)
+    def test_live_verbose(self):
+        self.override_config("log.console_level", logbook.INFO)
+        self._shake_run()
+        output = self.get_live_part()
+        self.assertIn('error_test.{0} ... error\n Traceback'.format(self.error_test._test_class_name), output)
+        self.assertIn('fail_test.{0} ... fail\n Traceback'.format(self.fail_test._test_class_name), output)
+        self.assertIn('skip_test.{0} ... skip\n Reason here'.format(self.skip_test._test_class_name), output)
+        self.assertIn('success_test.{0} ... ok'.format(self.success_test._test_class_name), output)
+    def test_summary(self):
+        self._shake_run()
+        output = self.get_summary_part()
+        headers, values = output.strip().splitlines()
+        self.assertEqual(values.split(), ['1'] * 4)
+    def test_exceptions_summary_verbose(self):
+        self.override_config("log.console_level", logbook.INFO)
+        self._shake_run()
+        output = self.get_exceptions_part()
+        self.assertEqual(output.count('>'), 3) # skip, error and fail
+        self.assertEqual(output.count('Traceback'), 2) # error and fail
+        self.assertIn("OSError: Sample exception", output) # error
+        self.assertIn("TestFailed: Test failed", output) # fail
+    def test_exceptions_summary_concise(self):
+        self.override_config("log.console_level", logbook.WARNING)
+        self._shake_run()
+        output = self.get_exceptions_part()
+        self.assertEqual(output.count('>'), 3) # skip, error and fail
+        self.assertEqual(output.count('Traceback'), 0) # not tracebacks!
+        self.assertIn("Sample exception", output) # error
+        self.assertIn("Test failed", output) # fail
+        


### PR DESCRIPTION
Open issues:
1. I changed the order of the 'update_result' and 'test_hooks' contexts. That way hooks have access to test results (prior to this change, test_error callbacks had to look at sys.exc_info. now they can look at session.get_result).
2. I'm considering a better design for the whole reporting thing:
- Consider a CaseResult object as parent for Skip, Fail, Pass and Error child classes. each of them will have a short description (like a '.' or a 'F') and long description (like 'ok' or a traceback or a skip reason).
- Once it's easy to do session.get_result(context.test).description() it'll be easier to implement other plugins that print to a socket or send an email. 
