### PR TITLE
Add str to cleaup

### DIFF
--- a/slash/cleanups.py
+++ b/slash/cleanups.py
@@ -13,6 +13,8 @@ class _Cleanup(object):
         self.critical = critical
     def __call__(self):
         return self.func(*self.args, **self.kwargs) # pylint: disable=W0142
+    def __str__(self):
+        return "{0} ({1},{2})".format(self.func, self.args, self.kwargs)
 
 def add_cleanup(_func, *args, **kwargs):
     """


### PR DESCRIPTION
This log line:

```
_logger.debug("Calling cleanup: {0}", cleanup)
```

Results in this log:

```
[2014-06-19 21:26] DEBUG: slash.cleanups: Calling cleanup: <slash.cleanups._Cleanup object at 0x10ca06d50>
```

Add a cleanup str method to fix.
