### PR TITLE
Change unix-specific behavior in _traverse_upwards

### DIFF
--- a/slash/core/local_config.py
+++ b/slash/core/local_config.py
@@ -48,7 +48,7 @@ class LocalConfig(object):
 
         while True:
             yield path
-            if path == os.path.sep:
+            if path == os.path.abspath(os.path.sep):
                 break
             new_path = os.path.dirname(path)
             assert new_path != path


### PR DESCRIPTION
On Windows, the root path for a drive is not the path seperator ('\').
However, os.path.abspath returns the expected result when used on the path seperator.
