### PR TITLE
sort test files in directory

### DIFF
--- a/slash/loader.py
+++ b/slash/loader.py
@@ -187,6 +187,6 @@ class Loader(object):
 def _walk(p):
     if os.path.isfile(p):
         return [p]
-    return sorted([os.path.join(dirname, filename)
-                   for dirname, _, filenames in os.walk(p)
-                   for filename in filenames])
+    return (os.path.join(dirname, filename)
+            for dirname, _, filenames in os.walk(p)
+            for filename in sorted(filenames))

--- a/slash/loader.py
+++ b/slash/loader.py
@@ -187,6 +187,6 @@ class Loader(object):
 def _walk(p):
     if os.path.isfile(p):
         return [p]
-    return (os.path.join(dirname, filename)
-            for dirname, _, filenames in os.walk(p)
-            for filename in filenames)
+    return sorted([os.path.join(dirname, filename)
+                   for dirname, _, filenames in os.walk(p)
+                   for filename in filenames])


### PR DESCRIPTION
simple change that allow to declare the order of tests in a directory.
before
```
slash run test_dir/
10 tests collected   
test_dir/a_00.py .  PASS
test_dir/a_04.py .  PASS
test_dir/a_06.py .  PASS
test_dir/a_01.py .  PASS
test_dir/a_07.py .  PASS
test_dir/a_08.py .  PASS
test_dir/a_03.py .  PASS
test_dir/a_02.py .  PASS
test_dir/a_09.py .  PASS
test_dir/a_05.py .  PASS
```

after
```
slash run test_dir/
10 tests collected   
test_dir/a_00.py .  PASS
test_dir/a_01.py .  PASS
test_dir/a_02.py .  PASS
test_dir/a_03.py .  PASS
test_dir/a_04.py .  PASS
test_dir/a_05.py .  PASS
test_dir/a_06.py .  PASS
test_dir/a_07.py .  PASS
test_dir/a_08.py .  PASS
test_dir/a_09.py .  PASS
```