### PR TITLE
[xunit-plugin] add test metadata

### DIFF
--- a/slash/plugins/builtin/xunit.py
+++ b/slash/plugins/builtin/xunit.py
@@ -48,10 +48,16 @@ class Plugin(PluginInterface):
 
     def _add_error(self, errortype):
         exc_type, exc_value, exc_tb = exc_info = sys.exc_info()
+        self.add_test_metadata(errortype,
+                               dict(type=exc_type.__name__,
+                                    message=str(exc_value)),
+                               get_traceback_string(exc_info))
+
+def add_test_metadata(self, title, attributes={}, content=None):
         test_element = self._get_xunit_elements_list()[-1]
-        error_element = E(errortype, dict(type=exc_type.__name__, message=str(exc_value)))
-        error_element.text = get_traceback_string(exc_info)
-        test_element.append(error_element)
+        data_element = E(title, attributes)
+        data_element = content
+        test_element.append(data_element)
 
     def _get_test_case_element(self, test):
         return E('testcase', dict(name=str(test), classname="{}.{}".format(test.__class__.__module__, test.__class__.__name__), time="0"))

--- a/slash/plugins/builtin/xunit.py
+++ b/slash/plugins/builtin/xunit.py
@@ -53,7 +53,9 @@ class Plugin(PluginInterface):
                                      message=str(exc_value)),
                                 get_traceback_string(exc_info))
 
-    def _add_test_metadata(self, title, attributes={}, content=None):
+    def _add_test_metadata(self, title, attributes=None, content=None):
+        if not attributes:
+            attributes = {}
         test_element = self._get_xunit_elements_list()[-1]
         data_element = E(title, attributes)
         data_element.text = content

--- a/slash/plugins/builtin/xunit.py
+++ b/slash/plugins/builtin/xunit.py
@@ -3,9 +3,11 @@ import socket
 import sys
 from ..interface import PluginInterface
 from ...ctx import context
-from ...utils.traceback_utils import get_traceback_string
+from ...utils.marks import mark
 from ...utils.conf_utils import Cmdline
+from ...utils.traceback_utils import get_traceback_string
 from slash import config as slash_config
+
 from xml.etree.ElementTree import (
     tostring as xml_to_string,
     Element as E,
@@ -48,12 +50,12 @@ class Plugin(PluginInterface):
 
     def _add_error(self, errortype):
         exc_type, exc_value, exc_tb = exc_info = sys.exc_info()
-        self._add_test_metadata(errortype,
-                                dict(type=exc_type.__name__,
-                                     message=str(exc_value)),
+        self.add_test_metadata(errortype,
+                                {'type': exc_type.__name__, 'message': str(exc_value)},
                                 get_traceback_string(exc_info))
 
-    def _add_test_metadata(self, title, attributes=None, content=None):
+    @mark("register_on", None)  # same as slash.plugins.registers_on, which cause circular ImportError
+    def add_test_metadata(self, title, attributes=None, content=None):
         if not attributes:
             attributes = {}
         test_element = self._get_xunit_elements_list()[-1]

--- a/slash/plugins/builtin/xunit.py
+++ b/slash/plugins/builtin/xunit.py
@@ -48,15 +48,15 @@ class Plugin(PluginInterface):
 
     def _add_error(self, errortype):
         exc_type, exc_value, exc_tb = exc_info = sys.exc_info()
-        self.add_test_metadata(errortype,
-                               dict(type=exc_type.__name__,
-                                    message=str(exc_value)),
-                               get_traceback_string(exc_info))
+        self._add_test_metadata(errortype,
+                                dict(type=exc_type.__name__,
+                                     message=str(exc_value)),
+                                get_traceback_string(exc_info))
 
-def add_test_metadata(self, title, attributes={}, content=None):
+    def _add_test_metadata(self, title, attributes={}, content=None):
         test_element = self._get_xunit_elements_list()[-1]
         data_element = E(title, attributes)
-        data_element = content
+        data_element.text = content
         test_element.append(data_element)
 
     def _get_test_case_element(self, test):


### PR DESCRIPTION
Add option to add extra data to the xunit xml.
```
xunit_plugin.add_test_metadata(title='system-out', content=test_url)  # add url to jenkins test results```