### PR TITLE
[xunit-plugin] fix "Failed to add error to result" error

### DIFF
--- a/slash/plugins/builtin/xunit.py
+++ b/slash/plugins/builtin/xunit.py
@@ -15,6 +15,7 @@ from xml.etree.ElementTree import (
 class Plugin(PluginInterface):
 
     _xunit_elements = None
+    _start_time = datetime.datetime.now()
 
     def _get_xunit_elements_list(self):
         returned = self._xunit_elements
@@ -56,6 +57,8 @@ class Plugin(PluginInterface):
         self._add_element(errortype, {'type': exc_type.__name__ if exc_type else '', 'message': str(exc_value)}, text=get_traceback_string(exc_info) if exc_value is not None else None)
 
     def _add_element(self, tag, attrib, text=None):
+        if not context.test:
+            return
         test_element = self._get_xunit_elements_list()[-1]
         element = E(tag, attrib)
         if text is not None:


### PR DESCRIPTION
Hi,

When getting an error outside the test (like import error), using xunit plugin add another error of "Failed to add error to result" which hide the real error.
The PR is suggestion of work-around about the issue

Thanks,
Eli