### PR TITLE
log: fix non-string logs emitting

### DIFF
--- a/slash/log.py
+++ b/slash/log.py
@@ -78,7 +78,7 @@ class ConsoleHandler(ColorizedHandlerMixin, logbook.StreamHandler):
     def format(self, record):
         orig_message = record.message
         should_truncate = self._truncate_errors or record.level < logbook.ERROR
-        if self._truncate_lines and len(orig_message) > self.MAX_LINE_LENGTH and should_truncate:
+        if self._truncate_lines and len(str(orig_message)) > self.MAX_LINE_LENGTH and should_truncate:
             record.message = "\n".join(self._truncate(line) for line in orig_message.splitlines())
         try:
             returned = super(ConsoleHandler, self).format(record)


### PR DESCRIPTION
logging cause a exception int/bool/None like:
```
Traceback (most recent call last):
  File "/local/lib/python2.7/site-packages/logbook/handlers.py", line 212, in handle
    self.emit(record)
  File "/local/lib/python2.7/site-packages/slash/log.py", line 97, in emit
    returned = super(ConsoleHandler, self).emit(record)
  File "/local/lib/python2.7/site-packages/logbook/handlers.py", line 579, in emit
    msg = self.format(record)
  File "/local/lib/python2.7/site-packages/slash/log.py", line 81, in format
    if self._truncate_lines and len(orig_message) > self.MAX_LINE_LENGTH and should_truncate:
TypeError: object of type 'int' has no len()
Logged from file test_a.py, line 29
```