### PR TITLE
Fix documentation for slash.run_tests.

### DIFF
--- a/doc/advanced_usage.rst
+++ b/doc/advanced_usage.rst
@@ -49,8 +49,9 @@ Sometimes you would like to run a sequence of tests that you control in fine det
 
  if __name__ == "__main__":
      with slash.Session() as s:
+         tests = slash.loader.Loader().get_runnables(["/my_path", ...])
          with s.get_started_context():
-             slash.run_tests(slash.loader.Loader().get_runnables(["/my_path", ...]))
+             slash.run_tests(tests)
 
 The parameter given above to :func:`slash.runner.run_tests` is merely an iterator yielding runnable tests. You can interfere or skip specific tests quite easily:
 


### PR DESCRIPTION
Must load tests for their hooks to be registered, which is used by get_started_context to call the session start and end hooks.