### PR TITLE
Support changing stop_on_error configuration during session

### DIFF
--- a/slash/runner.py
+++ b/slash/runner.py
@@ -26,11 +26,13 @@ def run_tests(iterable, stop_on_error=None):
     Runs tests from an iterable using the current session
     """
     # pylint: disable=maybe-no-member
+    def should_stop_on_error():
+        if stop_on_error is None:
+            return config.root.run.stop_on_error
+        return stop_on_error
+
     if context.session is None or not context.session.started:
         raise NoActiveSession("A session is not currently started")
-
-    if stop_on_error is None:
-        stop_on_error = config.root.run.stop_on_error
 
     test_iterator = PeekableIterator(iterable)
     last_filename = None
@@ -58,7 +60,7 @@ def run_tests(iterable, stop_on_error=None):
             if result.has_fatal_exception():
                 _logger.debug("Stopping on fatal exception")
                 break
-            if not result.is_success(allow_skips=True) and stop_on_error:
+            if not result.is_success(allow_skips=True) and should_stop_on_error():
                 _logger.debug("Stopping (run.stop_on_error==True)")
                 break
         else:

--- a/tests/test_running.py
+++ b/tests/test_running.py
@@ -76,7 +76,8 @@ def test_stop_on_fatal_exception(suite, suite_test, fatal_error_adder):
     suite.run()
 
 
-def test_stop_on_error(suite, suite_test, failure_type):
+@pytest.mark.parametrize('stop_through_config', [True, False])
+def test_stop_on_error(suite, suite_test, failure_type, stop_through_config, config_override):
     if failure_type == 'error':
         suite_test.when_run.error()
     elif failure_type == 'failure':
@@ -87,7 +88,13 @@ def test_stop_on_error(suite, suite_test, failure_type):
     for test in suite.iter_all_after(suite_test):
         test.expect_not_run()
 
-    suite.run(additional_args=['-x'])
+    if stop_through_config:
+        config_override('run.stop_on_error', True)
+        kwargs = {}
+    else:
+        config_override('run.stop_on_error', False)
+        kwargs = {'additional_args': ['-x']}
+    suite.run(**kwargs)
 
 
 def test_stop_on_error_unaffected_by_skips(suite, suite_test):


### PR DESCRIPTION
@vmalloc As we discussed a long time ago (sorry for the late PR), sometimes we run with `--pdb` flag but due to multiple errors we want to stop entering debugger.
This PR should fix it by removing the caching of `config.root.run.stop_on_error`.