### PR TITLE
Fix issue with some windows file path

### DIFF
--- a/slash/loader.py
+++ b/slash/loader.py
@@ -106,11 +106,13 @@ class Loader(object):
                 yield test
 
     def _iter_test_address(self, address):
+        drive, address = os.path.splitdrive(address)
         if ':' in address:
             path, address_in_file = address.split(':', 1)
         else:
             path = address
             address_in_file = None
+        path = os.path.join(drive, path)
 
 
         tests = list(self._iter_path(path))


### PR DESCRIPTION
When using a test path like ```c:\path\to\my\test.py``` this was incorrectly detected as path="c" and address_in_file="\path\to\my\test.py"