### PR TITLE
Normalize the case of a path when traversing upwards

### DIFF
--- a/slash/core/local_config.py
+++ b/slash/core/local_config.py
@@ -50,7 +50,7 @@ class LocalConfig(object):
 
         while True:
             yield path
-            if path == os.path.abspath(os.path.sep):
+            if os.path.normcase(path) == os.path.normcase(os.path.abspath(os.path.sep)):
                 break
             new_path = os.path.dirname(path)
             assert new_path != path

--- a/slash/loader.py
+++ b/slash/loader.py
@@ -106,11 +106,13 @@ class Loader(object):
                 yield test
 
     def _iter_test_address(self, address):
+        drive, address = os.path.splitdrive(address)
         if ':' in address:
             path, address_in_file = address.split(':', 1)
         else:
             path = address
             address_in_file = None
+        path = os.path.join(drive, path)
 
 
         tests = list(self._iter_path(path))


### PR DESCRIPTION
On windows this was causing issue if the drive letter specified by the user was lower case.