### PR TITLE
Use IPython 5.x LTS for Python version before 3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pyparsing
 vintage>=0.4.0
 
 IPython==1.2.1; implementation_name=='pypy'
-IPython; implementation_name!='pypy'
+IPython==5.*; implementation_name!='pypy' and python_version < '3.3'
+IPython; implementation_name!='pypy' and python_version >= '3.3'
 
 contextlib2; python_version<'3.3'


### PR DESCRIPTION
Python 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2.
When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
Beginning with IPython 6.0, Python 3.3 and above is required.