### PR TITLE
Adding colorama init and deinit (fix #668)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+* :feature:`668` Fixing console color is not working on windows
 * :feature:`662` Change email notification icon based on session success status
 * :release:`1.4.2 <13-8-2017>`
 * :bug:`-` Add ``current_config`` property to plugins

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -16,4 +16,5 @@ Special thanks go to these people for taking the time in improving Slash and pro
 
 * Alon Horev (@alonho)
 * Omer Gertel
+* Pierre-Luc Tessier Gagné
 

--- a/slash/frontend/main.py
+++ b/slash/frontend/main.py
@@ -2,6 +2,8 @@
 from __future__ import print_function
 import argparse
 import contextlib
+
+import colorama
 import logbook # pylint: disable=F0401
 import sys
 
@@ -60,7 +62,11 @@ def _setup_logging_context(args):
 
 #### For use with entry_points/console_scripts
 def main_entry_point():
-    sys.exit(main())
+    colorama.init()
+    try:
+        sys.exit(main())
+    finally:
+        colorama.deinit()
 
 if __name__ == "__main__":
     main_entry_point()


### PR DESCRIPTION
**On Windows, calling init() will filter ANSI escape sequences out of any
text sent to stdout or stderr, and replace them with equivalent Win32
calls.**

From Colorama readme:
https://github.com/tartley/colorama#initialisation

> Applications should initialise Colorama using:
> 
> ```python
> from colorama import init
> init()
> ```
> 
> On Windows, calling init() will filter ANSI escape sequences out of any
> text sent to stdout or stderr, and replace them with equivalent Win32
> calls.
> 
> On other platforms, calling init() has no effect (unless you request
> other optional functionality; see “Init Keyword Args”, below). By
> design, this permits applications to call init() unconditionally on
> all platforms, after which ANSI output should just work.
> 
> To stop using colorama before your program exits, simply call deinit().
> This will restore stdout and stderr to their original values, so that
> Colorama is disabled. To resume using Colorama again, call reinit();
> it is cheaper to calling init() again (but does the same thing).