### PR TITLE
Tests loader assumes dirnames returned sorted from os.walk

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+* :bug:`- major` Fix tests loading order for some FS types
 * :feature:`689` Added a new hook, ``interruption_added``, for registering exceptions which cause test/session interruptions
 * :feature:`686` ``assert_raises`` raises ``ExpectedExceptionNotCaught`` if exception wasn't caught also allowing inspection of the expected exception object
 * :bug:`684 major` Optimize test loading with ``--repeat-each`` and ``--repeat-all``

--- a/slash/loader.py
+++ b/slash/loader.py
@@ -260,6 +260,6 @@ def _walk(p):
         return
 
     for path, dirnames, filenames in os.walk(p):
-        dirnames[:] = [dirname for dirname in dirnames if not dirname.startswith('.')]
+        dirnames[:] = sorted(dirname for dirname in dirnames if not dirname.startswith('.'))
         for filename in sorted(filenames):
             yield os.path.join(path, filename)

--- a/tests/test_test_loading.py
+++ b/tests/test_test_loading.py
@@ -17,7 +17,8 @@ def test_normal_sorting(test_dir, names):
 def test_custom_ordering(test_dir, names, indices):
     @slash.hooks.tests_loaded.register # pylint: disable=no-member
     def tests_loaded(tests):                # pylint: disable=unused-variable
-        for (test, new_index) in zip(tests, indices):
+        for index, (test, new_index) in enumerate(zip(tests, indices)):
+            assert test.__slash__.file_path.endswith(names[index]), 'Tests are loaded in incorrect order'
             test.__slash__.set_sort_key(new_index)
     assert get_file_names(load(test_dir)) == _sorted_by_indices(names, indices)
 


### PR DESCRIPTION
On btrfs this assumption is wrong