### PR TITLE
Allow "repeat: x" in suite file

### DIFF
--- a/doc/slash_run.rst
+++ b/doc/slash_run.rst
@@ -25,7 +25,9 @@ You can also read tests from file or files which contain paths to run. Whitespac
 
   $ slash run -f file1.txt -f file2.txt
 
-Lines in suite files can optionally contain filters, restricting the tests actually loaded from them::
+Lines in suite files can optionally contain filters and repeat directive.
+
+Filter allows restricting the tests actually loaded from them::
 
   # my_suite_file.txt
   # this is the first test file
@@ -34,6 +36,15 @@ Lines in suite files can optionally contain filters, restricting the tests actua
   /path/to/other_tests.py # filter: not dangerous
 
 .. seealso:: The filter syntax is exactly like ``-k`` described below
+
+Repeat allows to repeat a line::
+
+  # my_suite_file.txt
+  # the next line will be repeated twice
+  /path/to/other_tests.py # repeat: 2
+  # you can use filter and repeat together
+  /path/to/other_tests.py # filter: not dangerous, repeat: 2
+
 
 Debugging & Failures
 --------------------

--- a/slash/utils/suite_files.py
+++ b/slash/utils/suite_files.py
@@ -1,6 +1,10 @@
 import os
+from collections import namedtuple
 
 from . import pattern_matching
+
+SuiteEntry = namedtuple('SuiteEntry', 'path, matcher, repeat')
+
 
 def iter_suite_file_paths(suite_files):
     for filename in suite_files:
@@ -12,18 +16,19 @@ def iter_suite_file_paths(suite_files):
                 if not path or path.startswith("#"):
                     continue
 
-                path, matcher, repeat = _parse_path_filter_and_repeat(path)
+                suite_entry = _parse_path_filter_and_repeat(path)
+                path = suite_entry.path
 
                 if not os.path.isabs(path):
                     path = os.path.abspath(os.path.join(dirname, path))
 
                 if not path.endswith('.py') and '.py:' not in path and not os.path.isdir(path):
                     for p, other_filter in iter_suite_file_paths([path]):
-                        yield p, _and_matchers(matcher, other_filter)
+                        yield p, _and_matchers(suite_entry.matcher, other_filter)
                     continue
 
-                for _ in range(repeat):
-                    yield path, matcher
+                for _ in range(suite_entry.repeat):
+                    yield path, suite_entry.matcher
 
 
 def _and_matchers(a, b):
@@ -36,7 +41,7 @@ def _and_matchers(a, b):
 
 def _parse_path_filter_and_repeat(line):
     if '#' not in line:
-        return line, None, 1
+        return SuiteEntry(line, None, 1)
 
     line, remainders = line.split('#', 1)
     line = line.strip()
@@ -50,4 +55,4 @@ def _parse_path_filter_and_repeat(line):
             matcher = pattern_matching.Matcher(remainder.split(':', 1)[1])
         if remainder.startswith('repeat:'):
             repeat = int(remainder.split(':', 1)[1])
-    return line, matcher, repeat
+    return SuiteEntry(line, matcher, repeat)

--- a/tests/test_suite_files.py
+++ b/tests/test_suite_files.py
@@ -88,7 +88,7 @@ def test_parse_repeat_string():
     'some_path.py # filter: bla, repeat: 5',
     'some_path.py # repeat: 5, filter: bla',
 ])
-def test_parse_repeat_string(string):
+def test_parse_repeat_string_with_filter(string):
     path, matcher, repeat = suite_files._parse_path_filter_and_repeat(
         string)  # pylint: disable=protected-access
     assert path == 'some_path.py'

--- a/tests/test_suite_files.py
+++ b/tests/test_suite_files.py
@@ -39,22 +39,22 @@ def test_suite_file_with_filter(suite, suite_test, suite_file):
 
 
 def test_parse_filter_string():
-    path, filter = suite_files._parse_path_and_filter('some_path.py # filter: bla')  # pylint: disable=protected-access
+    path, matcher, _ = suite_files._parse_path_filter_and_repeat('some_path.py # filter: bla')  # pylint: disable=protected-access
     assert path == 'some_path.py'
-    assert filter is not None
-    assert filter.matches('bla')
-    assert not filter.matches('blooop')
+    assert matcher is not None
+    assert matcher.matches('bla')
+    assert not matcher.matches('blooop')
 
 
 @pytest.mark.parametrize("string", [
     'some_path.py #',
     'some_path.py # bbb',
-    'some_path.py#',
+    'some_path.py#'
 ])
 def test_parse_filter_string_no_filter(string):
-    path, filter = suite_files._parse_path_and_filter(string)  # pylint: disable=protected-access
+    path, matcher, _ = suite_files._parse_path_filter_and_repeat(string)  # pylint: disable=protected-access
     assert path == 'some_path.py'
-    assert filter is None
+    assert matcher is None
 
 
 def test_iter_suite_file_paths_nested_filter(tmpdir):
@@ -69,11 +69,34 @@ def test_iter_suite_file_paths_nested_filter(tmpdir):
     with suite_file2.open('w') as f:
         print(test_filename, '# filter: green', file=f)
 
-    [(item, filter)] = suite_files.iter_suite_file_paths([str(suite_file1)])
+    [(item, matcher)] = suite_files.iter_suite_file_paths([str(suite_file1)])
     assert item == test_filename
-    assert filter.matches('green')
-    assert not filter.matches('blue')
-    assert not filter.matches('green blue')
+    assert matcher.matches('green')
+    assert not matcher.matches('blue')
+    assert not matcher.matches('green blue')
+
+
+def test_parse_repeat_string():
+    path, matcher, repeat = suite_files._parse_path_filter_and_repeat(
+        'some_path.py # repeat: 5')  # pylint: disable=protected-access
+    assert path == 'some_path.py'
+    assert matcher is None
+    assert repeat == 5
+
+
+@pytest.mark.parametrize("string", [
+    'some_path.py # filter: bla, repeat: 5',
+    'some_path.py # repeat: 5, filter: bla',
+])
+def test_parse_repeat_string(string):
+    path, matcher, repeat = suite_files._parse_path_filter_and_repeat(
+        string)  # pylint: disable=protected-access
+    assert path == 'some_path.py'
+    assert matcher is not None
+    assert matcher.matches('bla')
+    assert not matcher.matches('blooop')
+    assert matcher is not None
+    assert repeat == 5
 
 
 @pytest.fixture

--- a/tests/test_suite_files.py
+++ b/tests/test_suite_files.py
@@ -77,8 +77,7 @@ def test_iter_suite_file_paths_nested_filter(tmpdir):
 
 
 def test_parse_repeat_string():
-    path, matcher, repeat = suite_files._parse_path_filter_and_repeat(
-        'some_path.py # repeat: 5')  # pylint: disable=protected-access
+    path, matcher, repeat = suite_files._parse_path_filter_and_repeat('some_path.py # repeat: 5')  # pylint: disable=protected-access
     assert path == 'some_path.py'
     assert matcher is None
     assert repeat == 5
@@ -89,8 +88,7 @@ def test_parse_repeat_string():
     'some_path.py # repeat: 5, filter: bla',
 ])
 def test_parse_repeat_string_with_filter(string):
-    path, matcher, repeat = suite_files._parse_path_filter_and_repeat(
-        string)  # pylint: disable=protected-access
+    path, matcher, repeat = suite_files._parse_path_filter_and_repeat(string)  # pylint: disable=protected-access
     assert path == 'some_path.py'
     assert matcher is not None
     assert matcher.matches('bla')

--- a/tests/test_suite_files.py
+++ b/tests/test_suite_files.py
@@ -39,11 +39,11 @@ def test_suite_file_with_filter(suite, suite_test, suite_file):
 
 
 def test_parse_filter_string():
-    path, matcher, _ = suite_files._parse_path_filter_and_repeat('some_path.py # filter: bla')  # pylint: disable=protected-access
-    assert path == 'some_path.py'
-    assert matcher is not None
-    assert matcher.matches('bla')
-    assert not matcher.matches('blooop')
+    suite_entry = suite_files._parse_path_filter_and_repeat('some_path.py # filter: bla')  # pylint: disable=protected-access
+    assert suite_entry.path == 'some_path.py'
+    assert suite_entry.matcher is not None
+    assert suite_entry.matcher.matches('bla')
+    assert not suite_entry.matcher.matches('blooop')
 
 
 @pytest.mark.parametrize("string", [
@@ -52,9 +52,9 @@ def test_parse_filter_string():
     'some_path.py#'
 ])
 def test_parse_filter_string_no_filter(string):
-    path, matcher, _ = suite_files._parse_path_filter_and_repeat(string)  # pylint: disable=protected-access
-    assert path == 'some_path.py'
-    assert matcher is None
+    suite_entry = suite_files._parse_path_filter_and_repeat(string)  # pylint: disable=protected-access
+    assert suite_entry.path == 'some_path.py'
+    assert suite_entry.matcher is None
 
 
 def test_iter_suite_file_paths_nested_filter(tmpdir):
@@ -77,10 +77,10 @@ def test_iter_suite_file_paths_nested_filter(tmpdir):
 
 
 def test_parse_repeat_string():
-    path, matcher, repeat = suite_files._parse_path_filter_and_repeat('some_path.py # repeat: 5')  # pylint: disable=protected-access
-    assert path == 'some_path.py'
-    assert matcher is None
-    assert repeat == 5
+    suite_entry = suite_files._parse_path_filter_and_repeat('some_path.py # repeat: 5')  # pylint: disable=protected-access
+    assert suite_entry.path == 'some_path.py'
+    assert suite_entry.matcher is None
+    assert suite_entry.repeat == 5
 
 
 @pytest.mark.parametrize("string", [
@@ -88,13 +88,13 @@ def test_parse_repeat_string():
     'some_path.py # repeat: 5, filter: bla',
 ])
 def test_parse_repeat_string_with_filter(string):
-    path, matcher, repeat = suite_files._parse_path_filter_and_repeat(string)  # pylint: disable=protected-access
-    assert path == 'some_path.py'
-    assert matcher is not None
-    assert matcher.matches('bla')
-    assert not matcher.matches('blooop')
-    assert matcher is not None
-    assert repeat == 5
+    suite_entry = suite_files._parse_path_filter_and_repeat(string)  # pylint: disable=protected-access
+    assert suite_entry.path == 'some_path.py'
+    assert suite_entry.matcher is not None
+    assert suite_entry.matcher.matches('bla')
+    assert not suite_entry.matcher.matches('blooop')
+    assert suite_entry.matcher is not None
+    assert suite_entry.repeat == 5
 
 
 @pytest.fixture


### PR DESCRIPTION
Also renamed `filter` to `matcher` to avoid shadowing python built it name.

This change allow to have a suite file that looks like:
```
tests\test_1.py  # repeat: 5
tests\test_2.py  # repeat: 3
tests\test_4.py
tests  # filter: id=3, repeat: 4
tests  # repeat: 2, filter: abc
```