### PR TITLE
Adding repeat_all_index in test metadata to help sorting

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+* :bug:`710 major` Fix sorting when repeat-all option is use
 * :feature:`-` Suite files can now have a ``repeat: X`` marker to make the test run multiple times (Thanks @pierreluctg!)
 * :bug:`671 major` Help for ``slash resume`` is now more helpful
 * :feature:`685` use.X is now a shortcut for use('x') for fixture annotations

--- a/slash/core/metadata.py
+++ b/slash/core/metadata.py
@@ -20,6 +20,7 @@ class Metadata(object):
         self.id = None
         self.tags = test.get_tags()
         self._sort_key = next(_sort_key_generator)
+        self.repeat_all_index = 0
         if factory is not None:
             #: The path to the file from which this test was loaded
             self.module_name = factory.get_module_name()

--- a/slash/loader.py
+++ b/slash/loader.py
@@ -14,7 +14,6 @@ from sentinels import NOTHING
 from .conf import config
 from ._compat import string_types
 from .ctx import context
-from .core import metadata
 from .core.local_config import LocalConfig
 from .core.markers import repeat_marker
 from . import hooks

--- a/slash/loader.py
+++ b/slash/loader.py
@@ -14,6 +14,7 @@ from sentinels import NOTHING
 from .conf import config
 from ._compat import string_types
 from .ctx import context
+from .core import metadata
 from .core.local_config import LocalConfig
 from .core.markers import repeat_marker
 from . import hooks
@@ -65,7 +66,9 @@ class Loader(object):
             returned.insert(0, generate_interactive_test())
 
         hooks.tests_loaded(tests=returned) # pylint: disable=no-member
-        returned.sort(key=lambda test: test.__slash__.get_sort_key())
+        returned.sort(key=lambda test: (
+            test.__slash__.repeat_all_index, test.__slash__.get_sort_key()
+        ))
         return returned
 
 
@@ -78,7 +81,9 @@ class Loader(object):
         num_tests = len(returned)
         for i in range(config.root.run.repeat_all - 1):
             for test in itertools.islice(returned, 0, num_tests):
-                returned.append(test.clone())
+                clone = test.clone()
+                clone.__slash__.repeat_all_index = i + 1
+                returned.append(clone)
         return returned
 
 

--- a/tests/test_repeat.py
+++ b/tests/test_repeat.py
@@ -38,7 +38,9 @@ def test_repeat_all_global(suite, config_override):
     summary = suite.run()
 
     indices = [res.data['index'] for res in summary.session.results.iter_test_results()]
-    assert indices == [x for x in range(len(suite)) for _ in range(num_repetitions)]
+
+    expected = [[x for x in range(len(suite))] for _ in range(num_repetitions)]
+    assert indices == [item for sublist in expected for item in sublist]
 
 
 @pytest.mark.parametrize('repeat_mode', ['repeat_each', 'repeat_all'])


### PR DESCRIPTION
Adding repeat_all_index in test metadata to help sorting tests correctly when using repeat-all.

With the current implementation, repeat-each and repeat-all is producing the same list of tests.
If you have 3 tests called a, b and c. With `--repeat-each 2` or `--repeat-all 2` the result will be:
```
a
a
b
b
c
c
```

_____________________

Now with this change, 
`--repeat-each 2` the result will be:
```
a
a
b
b
c
c
```
`--repeat-all 2` the result will be:
```
a
b
c
a
b
c
```