### PR TITLE
Adding support for details coming from result.details.append in xunit

### DIFF
--- a/slash/plugins/builtin/xunit.py
+++ b/slash/plugins/builtin/xunit.py
@@ -59,7 +59,7 @@ class Plugin(PluginInterface):
 
     def _build_xml(self, r, d):
         if isinstance(d, dict):
-            for k, v in d.iteritems():
+            for k, v in d.items():
                 s = SE(r, k)
                 self._build_xml(s, v)
         elif isinstance(d, (tuple, list)):

--- a/tests/test_xunit_plugin.py
+++ b/tests/test_xunit_plugin.py
@@ -69,8 +69,9 @@ def _get_testcase_xml(suite_test, filename):
     return match[0]
 
 
-@pytest.fixture(params=['set', 'append', 'complex'])
+@pytest.fixture(params=['set', 'append'])
 def details(request, result):
+
     if request.param == 'set':
         result.details.set('detail1', 'value1')
         result.details.set('detail2', 'value2')
@@ -78,11 +79,6 @@ def details(request, result):
     if request.param == 'append':
         result.details.append('detail1', 'value1')
         result.details.append('detail1', 'value2')
-
-    if request.param == 'append':
-        result.details.append('detail1', 'value1')
-        result.details.append(
-            'detail1', {'complex': ['value2', 'value3', 4, 5]})
 
     return result.details.all()
 

--- a/tests/test_xunit_plugin.py
+++ b/tests/test_xunit_plugin.py
@@ -35,8 +35,15 @@ def test_xunit_plugin_test_details(suite, suite_test, xunit_filename, details):
 
     suite.run()
     testcase_xml = _get_testcase_xml(suite_test, xunit_filename)
+    saved_details = {}
+    for d in testcase_xml.findall('detail'):
+        k = d.attrib['name']
+        if 'value' in d.attrib:
+            v = d.attrib['value']
+        else:
+            v = [child for child in d]
+        saved_details[k] = v
 
-    saved_details = dict((d.attrib['name'], d.attrib['value']) for d in testcase_xml.findall('detail'))
     assert saved_details
 
 
@@ -69,7 +76,7 @@ def _get_testcase_xml(suite_test, filename):
     return match[0]
 
 
-@pytest.fixture(params=['set', 'append'])
+@pytest.fixture(params=['set', 'append', 'complex'])
 def details(request, result):
 
     if request.param == 'set':
@@ -79,6 +86,11 @@ def details(request, result):
     if request.param == 'append':
         result.details.append('detail1', 'value1')
         result.details.append('detail1', 'value2')
+
+    if request.param == 'complex':
+        result.details.append('detail1', 'value1')
+        result.details.append(
+            'detail1', {'complex': ['value2', 'value3']})
 
     return result.details.all()
 

--- a/tests/test_xunit_plugin.py
+++ b/tests/test_xunit_plugin.py
@@ -69,9 +69,22 @@ def _get_testcase_xml(suite_test, filename):
     return match[0]
 
 
-@pytest.fixture
-def details():
-    return {'detail1': 'value1', 'detail2': 'value2'}
+@pytest.fixture(params=['set', 'append', 'complex'])
+def details(request, result):
+    if request.param == 'set':
+        result.details.set('detail1', 'value1')
+        result.details.set('detail2', 'value2')
+
+    if request.param == 'append':
+        result.details.append('detail1', 'value1')
+        result.details.append('detail1', 'value2')
+
+    if request.param == 'append':
+        result.details.append('detail1', 'value1')
+        result.details.append(
+            'detail1', {'complex': ['value2', 'value3', 4, 5]})
+
+    return result.details.all()
 
 
 @pytest.fixture  # pylint: disable=unused-argument


### PR DESCRIPTION
Currently the xnuit plugin do not supports result details that are not
directly xml serializable. This includes details that can be added
using slash.context.result.details.append (detail value becomes a list).

With this change, slash.context.result.details.append is fully
supported in addition with supports for other detail values like dict,
list and tuple.