### PR TITLE
Removing double colon causing doc rendering issues

### DIFF
--- a/doc/fixtures.rst
+++ b/doc/fixtures.rst
@@ -220,7 +220,7 @@ You can also "force" a fixture to be used, even if it is not required by any fun
 The use_fixtures Decorator
 --------------------------
 
-In some cases, you may want to use a certain fixture but don't need its return value. In such cases, rather than using the fixture as an unused argument to your test function you can use the ``use_fixtures`` decorator. This decorator receives a list of fixture names and indicates that the decorated test needs them to run::
+In some cases, you may want to use a certain fixture but don't need its return value. In such cases, rather than using the fixture as an unused argument to your test function you can use the ``use_fixtures`` decorator. This decorator receives a list of fixture names and indicates that the decorated test needs them to run:
 
 .. code-block:: python
 


### PR DESCRIPTION
The double colon was causing issue when rendering the sphinx documentation.

See the code block bellow https://slash.readthedocs.io/en/develop/fixtures.html#the-use-fixtures-decorator