### PR TITLE
Correctly call fixture test_start for each test

### DIFF
--- a/slash/core/fixtures/fixture_store.py
+++ b/slash/core/fixtures/fixture_store.py
@@ -68,17 +68,18 @@ class FixtureStore(object):
         else:
             kwargs = {}
 
-        if trigger_test_start:
-            for fixture in self.iter_active_fixtures():
-                fixture.call_test_start()
-
         try:
-            return test_func(**kwargs)
-        finally:
-            if trigger_test_end:
+            if trigger_test_start:
                 for fixture in self.iter_active_fixtures():
-                    with handling_exceptions(swallow=True):
-                        fixture.call_test_end()
+                    fixture.call_test_start()
+        finally:
+            try:
+                return test_func(**kwargs)  # pylint: disable=lost-exception
+            finally:
+                if trigger_test_end:
+                    for fixture in self.iter_active_fixtures():
+                        with handling_exceptions(swallow=True):
+                            fixture.call_test_end()
 
     def get_required_fixture_names(self, test_func):
         """Returns a list of fixture names needed by test_func.


### PR DESCRIPTION
Currently if there is an exception raised from one of the fixture test_start, the test before and other tests method are not called. In addition, this fixture test_start will not be called again until all the fixtures test_start have been called once without exceptions. This leads to funky results...

```python
import slash


@slash.fixture(scope='session')
def fixture1(this):
    slash.logger.info("Hi from fixture 1")

    @this.test_start
    def at_test_start():
        slash.logger.info("on test start fixture 1")
        raise Exception("from fixture 1")
    return 1


@slash.fixture(scope='session')
def fixture2(this):
    slash.logger.info("Hi from fixture 2")

    @this.test_start
    def at_test_start():
        slash.logger.info("on test start fixture 2")
        raise AssertionError("from fixture 2")
    return 2

class Sample(slash.Test):

    def before(self, fixture1, fixture2):
        self.one = fixture1
        self.two = fixture2

    @slash.parametrize('i', range(5))
    def test_sample(self, i):
        slash.logger.info("Hello Sample {}".format(i))
        slash.logger.info(self.one)
        slash.logger.info(self.two)
```