### PR TITLE
Windows path upward limit for path is not always cwd drive

### DIFF
--- a/slash/core/local_config.py
+++ b/slash/core/local_config.py
@@ -48,9 +48,11 @@ class LocalConfig(object):
         if os.path.isfile(path):
             path = os.path.dirname(path)
 
+        upward_limit = os.path.splitdrive(os.path.normcase(os.path.abspath(os.path.sep)))[1]
+
         while True:
             yield path
-            if os.path.normcase(path) == os.path.normcase(os.path.abspath(os.path.sep)):
+            if os.path.splitdrive(os.path.normcase(path))[1] == upward_limit:
                 break
             new_path = os.path.dirname(path)
             assert new_path != path


### PR DESCRIPTION
On Windows `os.path.normcase(os.path.abspath(os.path.sep))` return the cwd root, i.e. `c:\\`. This is causing issues in the _traverse_upwards method when `path` in not on the same drive.