### PR TITLE
Modifying the fixture test_start unit test to fix active fixture order

### DIFF
--- a/tests/test_fixture_start_end_test.py
+++ b/tests/test_fixture_start_end_test.py
@@ -60,34 +60,28 @@ def test_fixture_start_test_raises_exception(suite_builder):
         import slash  # pylint: disable=redefined-outer-name, reimported
 
         @slash.fixture(scope='module')
-        @slash.parametrize("param", [1, 2])
-        def fixture(this, param):
+        def fixture(this):
             @this.test_start
             def test_start(*_, **__):
                 1 / 0  # pylint: disable=pointless-statement
 
-            return param
+            return None
 
         @slash.fixture(scope='module')
-        def fixture_failing(this):
+        @slash.parametrize("param", [1, 2])
+        def fixture_failing(this, param):
             @this.test_start
             def test_start(*_, **__):
-                raise AssertionError()
+                slash.add_error("Not supposed to reach here").mark_fatal()
 
-            return None
+            return param
 
         class SomeTest(slash.Test):
             @slash.parametrize("param", [10, 20, 30])
             def test_something(self, param, fixture, fixture_failing):  # pylint: disable=unused-argument
-                slash.context.result.data["value"] = param + fixture
+                slash.add_error("Not supposed to reach here").mark_fatal()
 
-    suite_builder.build().run().assert_all(6).exception(ZeroDivisionError).with_data(
-        [
-            {"value": 11}, {"value": 12},
-            {"value": 21}, {"value": 22},
-            {"value": 31}, {"value": 32}
-        ]
-    )
+    suite_builder.build().run().assert_all(6).exception(ZeroDivisionError)
 
 
 def test_fixture_start_test_raises_exception_w_before(suite_builder):
@@ -97,34 +91,28 @@ def test_fixture_start_test_raises_exception_w_before(suite_builder):
         import slash  # pylint: disable=redefined-outer-name, reimported
 
         @slash.fixture(scope='module')
-        @slash.parametrize("param", [1, 2])
-        def fixture(this, param):
+        def fixture(this):
             @this.test_start
             def test_start(*_, **__):
                 1 / 0  # pylint: disable=pointless-statement
 
-            return param
+            return None
 
         @slash.fixture(scope='module')
-        def fixture_failing(this):
+        @slash.parametrize("param", [1, 2])
+        def fixture_failing(this, param):
             @this.test_start
             def test_start(*_, **__):
-                raise AssertionError()
+                slash.add_error("Not supposed to reach here").mark_fatal()
 
-            return None
+            return param
 
         class SomeTest(slash.Test):
             def before(self, fixture, fixture_failing):  # pylint: disable=unused-argument,arguments-differ
-                self.data = fixture
+                self.data = 1
 
             @slash.parametrize("param", [10, 20, 30])
-            def test_something(self, param):
-                slash.context.result.data["value"] = param + self.data
+            def test_something(self, param, fixture, fixture_failing):
+                slash.add_error("Not supposed to reach here").mark_fatal()
 
-    suite_builder.build().run().assert_all(6).exception(ZeroDivisionError).with_data(
-        [
-            {"value": 11}, {"value": 12},
-            {"value": 21}, {"value": 22},
-            {"value": 31}, {"value": 32}
-        ]
-    )
+    suite_builder.build().run().assert_all(6).exception(ZeroDivisionError)


### PR DESCRIPTION
Previous implementation had parametrization on the fixture raising
ZeroDivisionError, this caused the second fixture called first staring
on the second tests.

This is because only the second fixture stay active.

I am not sure if we should fix this since we are not always honoring
the order of the fixture in the test method argument.