### PR TITLE
Correctly propagating exceptions out of the test_start or test_end hooks

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+* :bug:`930` Restore behavior of exceptions propagating out of the test_start or test_end hooks will fail the test, possibly preventing it from starting properly
 * :release:`1.7.8 <04-03-2019>`
 * :bug:`925` Fix background color for session start and test collection messages
 * :bug:`926` Return code for failed sessions was changed to 1 (from -1)

--- a/slash/core/fixtures/fixture_store.py
+++ b/slash/core/fixtures/fixture_store.py
@@ -72,14 +72,13 @@ class FixtureStore(object):
             if trigger_test_start:
                 for fixture in self.iter_active_fixtures():
                     fixture.call_test_start()
+
+            return test_func(**kwargs)  # pylint: disable=lost-exception
         finally:
-            try:
-                return test_func(**kwargs)  # pylint: disable=lost-exception
-            finally:
-                if trigger_test_end:
-                    for fixture in self.iter_active_fixtures():
-                        with handling_exceptions(swallow=True):
-                            fixture.call_test_end()
+            if trigger_test_end:
+                for fixture in self.iter_active_fixtures():
+                    with handling_exceptions(swallow=True):
+                        fixture.call_test_end()
 
     def get_required_fixture_names(self, test_func):
         """Returns a list of fixture names needed by test_func.

--- a/slash/core/test.py
+++ b/slash/core/test.py
@@ -118,7 +118,7 @@ class Test(RunnableTest):
         method = self.get_test_function()
         with bound_parametrizations_context(self._variation, self._fixture_store, self._fixture_namespace):
             _call_with_fixtures = functools.partial(self._fixture_store.call_with_fixtures, namespace=self._fixture_namespace)
-            _call_with_fixtures(self.before, trigger_test_start=True)
+            _call_with_fixtures(self.before)
             try:
                 with handling_exceptions():
                     result = _call_with_fixtures(method, trigger_test_start=True)

--- a/tests/test_fixture_start_end_test.py
+++ b/tests/test_fixture_start_end_test.py
@@ -60,34 +60,28 @@ def test_fixture_start_test_raises_exception(suite_builder):
         import slash  # pylint: disable=redefined-outer-name, reimported
 
         @slash.fixture(scope='module')
-        @slash.parametrize("param", [1, 2])
-        def fixture(this, param):
+        def fixture(this):
             @this.test_start
             def test_start(*_, **__):
                 1 / 0  # pylint: disable=pointless-statement
 
-            return param
+            return None
 
         @slash.fixture(scope='module')
-        def fixture_failing(this):
+        @slash.parametrize("param", [1, 2])
+        def fixture_failing(this, param):
             @this.test_start
             def test_start(*_, **__):
-                raise AssertionError()
+                slash.add_error("Not supposed to reach here").mark_fatal()
 
-            return None
+            return param
 
         class SomeTest(slash.Test):
             @slash.parametrize("param", [10, 20, 30])
             def test_something(self, param, fixture, fixture_failing):  # pylint: disable=unused-argument
-                slash.context.result.data["value"] = param + fixture
+                slash.add_error("Not supposed to reach here").mark_fatal()
 
-    suite_builder.build().run().assert_all(6).exception(ZeroDivisionError).with_data(
-        [
-            {"value": 11}, {"value": 12},
-            {"value": 21}, {"value": 22},
-            {"value": 31}, {"value": 32}
-        ]
-    )
+    suite_builder.build().run().assert_all(6).exception(ZeroDivisionError)
 
 
 def test_fixture_start_test_raises_exception_w_before(suite_builder):
@@ -97,34 +91,28 @@ def test_fixture_start_test_raises_exception_w_before(suite_builder):
         import slash  # pylint: disable=redefined-outer-name, reimported
 
         @slash.fixture(scope='module')
-        @slash.parametrize("param", [1, 2])
-        def fixture(this, param):
+        def fixture(this):
             @this.test_start
             def test_start(*_, **__):
                 1 / 0  # pylint: disable=pointless-statement
 
-            return param
+            return None
 
         @slash.fixture(scope='module')
-        def fixture_failing(this):
+        @slash.parametrize("param", [1, 2])
+        def fixture_failing(this, param):
             @this.test_start
             def test_start(*_, **__):
-                raise AssertionError()
+                slash.add_error("Not supposed to reach here").mark_fatal()
 
-            return None
+            return param
 
         class SomeTest(slash.Test):
             def before(self, fixture, fixture_failing):  # pylint: disable=unused-argument,arguments-differ
-                self.data = fixture
+                self.data = 1
 
             @slash.parametrize("param", [10, 20, 30])
-            def test_something(self, param):
-                slash.context.result.data["value"] = param + self.data
+            def test_something(self, param, fixture, fixture_failing):
+                slash.add_error("Not supposed to reach here").mark_fatal()
 
-    suite_builder.build().run().assert_all(6).exception(ZeroDivisionError).with_data(
-        [
-            {"value": 11}, {"value": 12},
-            {"value": 21}, {"value": 22},
-            {"value": 31}, {"value": 32}
-        ]
-    )
+    suite_builder.build().run().assert_all(6).exception(ZeroDivisionError)

--- a/tests/test_fixture_start_end_test.py
+++ b/tests/test_fixture_start_end_test.py
@@ -60,25 +60,17 @@ def test_fixture_start_test_raises_exception(suite_builder):
         import slash  # pylint: disable=redefined-outer-name, reimported
 
         @slash.fixture(scope='module')
-        def fixture(this):
+        @slash.parametrize("param", [1, 2])
+        def fixture(this, param):
             @this.test_start
             def test_start(*_, **__):
                 1 / 0  # pylint: disable=pointless-statement
-
-            return None
-
-        @slash.fixture(scope='module')
-        @slash.parametrize("param", [1, 2])
-        def fixture_failing(this, param):
-            @this.test_start
-            def test_start(*_, **__):
-                slash.add_error("Not supposed to reach here").mark_fatal()
 
             return param
 
         class SomeTest(slash.Test):
             @slash.parametrize("param", [10, 20, 30])
-            def test_something(self, param, fixture, fixture_failing):  # pylint: disable=unused-argument
+            def test_something(self, param, fixture):  # pylint: disable=unused-argument
                 slash.add_error("Not supposed to reach here").mark_fatal()
 
     suite_builder.build().run().assert_all(6).exception(ZeroDivisionError)
@@ -91,28 +83,20 @@ def test_fixture_start_test_raises_exception_w_before(suite_builder):
         import slash  # pylint: disable=redefined-outer-name, reimported
 
         @slash.fixture(scope='module')
-        def fixture(this):
+        @slash.parametrize("param", [1, 2])
+        def fixture(this, param):
             @this.test_start
             def test_start(*_, **__):
                 1 / 0  # pylint: disable=pointless-statement
 
-            return None
-
-        @slash.fixture(scope='module')
-        @slash.parametrize("param", [1, 2])
-        def fixture_failing(this, param):
-            @this.test_start
-            def test_start(*_, **__):
-                slash.add_error("Not supposed to reach here").mark_fatal()
-
             return param
 
         class SomeTest(slash.Test):
-            def before(self, fixture, fixture_failing):  # pylint: disable=unused-argument,arguments-differ
+            def before(self, fixture):  # pylint: disable=unused-argument,arguments-differ
                 self.data = 1
 
             @slash.parametrize("param", [10, 20, 30])
-            def test_something(self, param, fixture, fixture_failing):
+            def test_something(self, param):  # pylint: disable=unused-argument
                 slash.add_error("Not supposed to reach here").mark_fatal()
 
     suite_builder.build().run().assert_all(6).exception(ZeroDivisionError)


### PR DESCRIPTION
Restoring the behavior described in the **note** section here https://slash.readthedocs.io/en/master/fixtures.html#test-start-end-for-widely-scoped-fixtures

> Note: 
Exceptions propagating out of the test_start or test_end hooks will fail the test, possibly preventing it from starting properly