### PR TITLE
add hook before parallel workers start and after they're all terminated

### DIFF
--- a/slash/hooks.py
+++ b/slash/hooks.py
@@ -68,6 +68,8 @@ _define('prepare_notification', doc='Called with a message object prior to it be
         arg_names=("message",))
 
 _define('before_interactive_shell', doc='Called before starting interactive shell', arg_names=("namespace",))
+_define('before_parallel_session_start', doc='Called before all parallel workers are initiated')
+_define('after_parallel_session_end', doc='Called after all parallel workers joined')
 
 _slash_group = gossip.get_group('slash')
 _slash_group.set_strict()

--- a/slash/parallel/parallel_manager.py
+++ b/slash/parallel/parallel_manager.py
@@ -158,6 +158,7 @@ class ParallelManager(object):
             self.handle_error("No request sent to server for {} seconds, terminating".format(config.root.parallel.no_request_timeout))
 
     def start(self):
+        hooks.before_parallel_session_start()  # pylint: disable=no-member
         self.try_connect()
         if not config.root.parallel.server_port:
             self.args.extend(['--parallel-port', str(self.server.port)])
@@ -191,3 +192,4 @@ class ParallelManager(object):
             get_xmlrpc_proxy(config.root.parallel.server_addr, self.keepalive_server.port).stop_serve()
             self.server_thread.join()
             self.keepalive_server_thread.join()
+            hooks.after_parallel_session_end()  # pylint: disable=no-member


### PR DESCRIPTION
Hi,

This PR comes after realizing that `session_start` and `session_end` hooks are invoked for each slash session that is started/ends when using the parallel worker.
Which means the code in the hook is run NUM_OF_PARALLEL_WORKES + 1 (for the main session).
I my use case I need to do setup before the workers start and teardown after they're done.
I think it's a nice feature to have, but if there's a solution I'm not aware of I would happily try it.