### PR TITLE
Add support for tagging parameterization values

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,5 +1,6 @@
 Changelog
 =========
+* :feature:`-` Added support for tagging test parameterization values
 * :release:`1.8.0 <03-07-2019>`
 * :feature:`945` Drop support for deprecated arguments of ``add_cleanup``
 * :feature:`452` Drop support for old-style assertions

--- a/slash/core/fixtures/parameters.py
+++ b/slash/core/fixtures/parameters.py
@@ -8,6 +8,7 @@ from ..._compat import iteritems
 from ...exceptions import ParameterException
 from ...exception_handling import mark_exception_frame_correction
 from ...utils.python import wraps, get_argument_names
+from ..tagging import Tags
 from .fixture_base import FixtureBase
 from .utils import FixtureInfo, get_scope_by_name
 
@@ -147,6 +148,9 @@ class Parametrization(FixtureBase):
     def get_value_by_index(self, index):
         return self.transform(self._compute_value(self.values[index]))
 
+    def get_tags_by_index(self, index):
+        return self.values[index].tags
+
     def _compute_value(self, param):
         if isinstance(param, list):
             return [p.value for p in param]
@@ -174,11 +178,18 @@ class Parametrization(FixtureBase):
 
 class ParametrizationValue(object):
 
-    def __init__(self, label, value=NOTHING):
+    def __init__(self, label=NOTHING, value=NOTHING, tags=None):
         super(ParametrizationValue, self).__init__()
         self._validate_label(label)
         self.label = label
         self.value = value
+        self.tags = Tags()
+        if tags:
+            if not isinstance(tags, list):
+                tags = [tags]
+            for tag in tags:
+                name, value = tag if isinstance(tag, tuple) else (tag, NOTHING)
+                self.tags[name] = value
 
     def _validate_label(self, label):
         if isinstance(label, str) and not re.match(r'^[a-zA-Z_][0-9a-zA-Z_]{0,29}$', label):

--- a/slash/core/function_test.py
+++ b/slash/core/function_test.py
@@ -16,7 +16,7 @@ class FunctionTest(RunnableTest):
         self._func = function
 
     def get_tags(self):
-        test_tags = get_tags(self._func)
+        test_tags = get_tags(self._func) + self._variation.tags
         if nofixtures.is_marked(self.get_test_function()):
             return test_tags
         return test_tags + self._get_fixture_tags()

--- a/slash/core/tagging.py
+++ b/slash/core/tagging.py
@@ -1,11 +1,24 @@
-import functools
-
 from sentinels import NOTHING
 
 from .._compat import iteritems
 from ..exceptions import TaggingConflict
 
 _TAGS_NAME = '__slash_tags__'
+
+
+class Tagger(object):
+
+    def __init__(self, tag_name, tag_value):
+        self.tag_name = tag_name
+        self.tag_value = tag_value
+
+    def __call__(self, target):
+        assert callable(target)
+        return tag_test(target, self.tag_name, self.tag_value)
+
+    def __rfloordiv__(self, other):
+        from .fixtures.parameters import ParametrizationValue
+        return ParametrizationValue(value=other, tags=[(self.tag_name, self.tag_value)])
 
 
 def tag_test(test, tag_name, tag_value):
@@ -22,7 +35,7 @@ def tag_test(test, tag_name, tag_value):
 def tag(tag_name, tag_value=NOTHING):
     """Decorator for tagging tests
     """
-    return functools.partial(tag_test, tag_name=tag_name, tag_value=tag_value)
+    return Tagger(tag_name=tag_name, tag_value=tag_value)
 
 
 def get_tags(test):

--- a/slash/core/variation.py
+++ b/slash/core/variation.py
@@ -3,6 +3,7 @@ import string
 import json
 import logbook
 from .._compat import string_types
+from .tagging import Tags
 
 _PRINTABLE_TYPES = (Number,) + string_types
 _PRINTABLE_CHARS = set(string.ascii_letters) | set(string.digits) | set("-_")
@@ -36,10 +37,12 @@ class Variation(object):
         self.id = {}
         self.values = {}
         self.labels = {}
+        self.tags = Tags()
         for param_name, param in param_name_bindings.items():
             value_index = self.id[param_name] = param_value_indices[param.info.id]
             self.values[param_name] = param.get_value_by_index(value_index)
             self.labels[param_name] = param.values[value_index].label
+            self.tags.update(param.get_tags_by_index(value_index))
         self.safe_repr = self._get_safe_repr()
 
     def _get_safe_repr(self):

--- a/tests/utils/suite_builder.py
+++ b/tests/utils/suite_builder.py
@@ -44,8 +44,8 @@ class SuiteBuilderSuite(object):
         self.path = path
         os.makedirs(path)
 
-    def run(self):
-        app = slash_run([self.path])
+    def run(self, *args):
+        app = slash_run([self.path] + list(args))
         assert not app.session.has_internal_errors(), 'Session has internal errors!'
         return SuiteBuilderSuiteResult(app)
 


### PR DESCRIPTION
How about this?
Not sure which style is most appropriate:
```
@slash.parametrize('x', [
    500 // slash.param(tags=["regression"]),
    5 // slash.param(tags="sanity"),
])
@slash.parametrize('y', [
    '100' // slash.tag("regression", "long"),
    '10' // slash.tag("regression", "short"),
    '1' // slash.tag("sanity"),
])
@slash.parametrize('z', [True, False])
def test_1(x, y, z):
    print(x, y, z)
```

There's one issue though when using tags with different values on different parameter-values, which generates tag conflicts.