### PR TITLE
Fix documentation pipeline

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,10 @@ testing =
 doc =
     alabaster
     docutils
-    releases
-    Sphinx>=1.7.1
+    # All bellow pinning is due to: https://github.com/bitprophet/releases/issues/84
+    semantic-version==2.6.0
+    releases~=1.6.1
+    Sphinx~=1.7.1
 
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
Releases package is currently broken with newest `semantic-version` package, which is one of its dependencies (see https://github.com/bitprophet/releases/issues/84).

In addition, it depends on Sphinx<1.8.

I pinned these 3 packages (in doc extras) until the issue will be fixed.