### PR TITLE
Read file as binary

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,5 +1,6 @@
 Changelog
 =========
+* :feature:`-` Read files as binary to avoid decoding errors
 * :feature:`979` Change Ordered set implementation from orderedset to ordered-set, as the former is not maintained anymore
 * :feature:`598` Drop support for python version < 3.6
 * :feature:`-` Added support for tagging test parameterization values

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,6 @@
 Changelog
 =========
-* :feature:`-` Read files as binary to avoid decoding errors
+* :feature:`982` Read files as binary to avoid decoding errors
 * :feature:`979` Change Ordered set implementation from orderedset to ordered-set, as the former is not maintained anymore
 * :feature:`598` Drop support for python version < 3.6
 * :feature:`-` Added support for tagging test parameterization values

--- a/slash/utils/python.py
+++ b/slash/utils/python.py
@@ -14,7 +14,7 @@ PYPY = hasattr(sys, 'pypy_version_info')
 
 def check_duplicate_functions(path):
     code = None
-    with open(path) as f:
+    with open(path, 'rb') as f:
         code = f.read()
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')


### PR DESCRIPTION
This will avoid decoding errors when files are in different encodings