### PR TITLE
don't set attributes on threading.Event objects

### DIFF
--- a/slash/utils/interactive.py
+++ b/slash/utils/interactive.py
@@ -63,11 +63,14 @@ def _humanize_time_delta(seconds):
 @contextmanager
 def notify_if_slow_context(message, slow_seconds=1, end_message=None, show_duration=True):
     evt = threading.Event()
-    evt.should_report_end_msg = False
+    should_report_end_msg = False
+
     def notifier():
+        nonlocal should_report_end_msg
         if not evt.wait(timeout=slow_seconds) and context.session is not None:
             context.session.reporter.report_message(message)
-            evt.should_report_end_msg = True
+            should_report_end_msg = True
+
     thread = threading.Thread(target=notifier)
     start_time = time.time()
     thread.start()
@@ -77,7 +80,7 @@ def notify_if_slow_context(message, slow_seconds=1, end_message=None, show_durat
     finally:
         evt.set()
         thread.join()
-        if evt.should_report_end_msg and end_message is not None:
+        if should_report_end_msg and end_message is not None:
             if show_duration:
                 end_message += ' (took {})'.format(_humanize_time_delta(time.time() - start_time))
             context.session.reporter.report_message(end_message)


### PR DESCRIPTION
We use gevent's monkey patching which has 'read-only' version of these objects, and we fail:

```
Traceback (most recent call last):
  */slash/frontend/slash_run.py:64 ................ slash_run >> with app.session.get_started_context():                  
  /usr/local/lib/python3.7/contextlib.py:112 ...... __enter__ >> return next(self.gen)                                    
  */slash/core/session.py:122 ........... get_started_context >> with notify_if_slow_context("Initializing session..."):  
  /usr/local/lib/python3.7/contextlib.py:112 ...... __enter__ >> return next(self.gen)                                    
  */slash/utils/interactive.py:66 .... notify_if_slow_context >> evt.should_report_end_msg = False                        
AttributeError: 'gevent._event.Event' object has no attribute 'should_report_end_msg'
```