### PR TITLE
Cleanups

### DIFF
--- a/doc/fixtures.rst
+++ b/doc/fixtures.rst
@@ -272,7 +272,7 @@ Fortunately, Slash allows you to *alias* fixtures, using the :func:`slash.use` s
 .. versionadded: 1.0
 
 
-.. note:: Fixture aliases require Python 3.x, as they rely on `function argument annotation <https://www.python.org/dev/peps/pep-3107/>`_
+.. note:: Fixture aliases rely on `function argument annotation <https://www.python.org/dev/peps/pep-3107/>`_
 
 
 Misc. Utilities

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-timeout_method = signal
-addopts = -ra -W error::DeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,3 +43,5 @@ doc =
 
 [tool:pytest]
 testpaths = tests
+timeout_method = signal
+addopts = -ra -W error::DeprecationWarning

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -152,18 +152,6 @@ def test_handling_exceptions():
     assert handled3.exception is value
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 0), reason='Cannot run on 3.x')
-def test_reraise_after_exc_info_reset():
-    @gossip.register('slash.exception_caught_before_debugger')
-    def exception_hook():       # pylint: disable=unused-variable
-        sys.exc_clear()  # pylint: disable=no-member
-
-    with slash.Session(), pytest.raises(CustomException):
-        with exception_handling.handling_exceptions():
-            raise CustomException()
-
-
-
 class DebuggingTest(TestCase):
 
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37
+envlist = py36,py37,py38
 
 [testenv]
 commands =


### PR DESCRIPTION
* Remove python 2.x code/documentaion
* Add python3.8 to tox configuration
* Consolidate pytest configuration to single file (pytest.ini -> setup.cfg)