### PR TITLE
Fix for bug #948

### DIFF
--- a/slash/loader.py
+++ b/slash/loader.py
@@ -125,7 +125,7 @@ class Loader(object):
 
     def _iter_test_resume(self, resume_state):
         for test in self._iter_path(resume_state.file_name):
-            if resume_state.function_name == test.__slash__.address_in_file:
+            if resume_state.address_in_file == test.__slash__.address_in_file:
                 if resume_state.variation:
                     if not resume_state.variation == test.get_variation().id:
                         continue

--- a/slash/resuming.py
+++ b/slash/resuming.py
@@ -102,7 +102,7 @@ def save_resume_state(session_result, collected_tests):
     tests_to_resume = []
     for result in session_result.iter_test_results():
         metadata = result.test_metadata
-        test_to_resume = ResumeState(session_id=session_result.session.id, file_name=metadata.file_path, function_name=metadata.function_name)
+        test_to_resume = ResumeState(session_id=session_result.session.id, file_name=metadata.file_path, function_name=metadata.address_in_file)
         test_to_resume.variation = str(metadata.variation.id) if metadata.variation else None
         if result.is_success_finished():
             test_to_resume.status = ResumeTestStatus.SUCCESS
@@ -115,7 +115,7 @@ def save_resume_state(session_result, collected_tests):
 
     for test_metadata in tests_with_no_results:
         test_to_resume = ResumeState(session_id=session_result.session.id, file_name=test_metadata.file_path,\
-                                     function_name=test_metadata.function_name, status=ResumeTestStatus.PLANNED)
+                                     function_name=test_metadata.address_in_file, status=ResumeTestStatus.PLANNED)
         test_to_resume.variation = str(test_metadata.variation.id) if test_metadata.variation else None
         tests_to_resume.append(test_to_resume)
 

--- a/tests/test_slash_resume.py
+++ b/tests/test_slash_resume.py
@@ -42,7 +42,7 @@ def test_resume_with_parametrization(suite, suite_test):
 
     assert len(summary.get_all_results_for_test(suite_test)) == num_values1 * num_values2
     assert len(resumed) == 1
-    assert resumed[0].function_name == address_in_file(suite[fail_index])
+    assert resumed[0].address_in_file == address_in_file(suite[fail_index])
 
 def test_different_folder_no_resume_session_id(suite, tmpdir):  # pylint: disable=unused-argument
     fail_index = len(suite) // 2
@@ -90,7 +90,7 @@ def test_failed_first_or_unstarted_first(suite, failed_first, config_override):
     assert len(order_after_changing_config) + result.session.results.get_num_started() - 2 == len(suite)
 
     first_test_in_resumed_suite = fail_index if failed_first else skip_index
-    assert order_after_changing_config[0].function_name == address_in_file(suite[first_test_in_resumed_suite])
+    assert order_after_changing_config[0].address_in_file == address_in_file(suite[first_test_in_resumed_suite])
 
     if failed_first:
         assert regular_order[1] == order_after_changing_config[0]
@@ -113,7 +113,7 @@ def test_failed_or_unstarted_with_no_such_tests(suite, failed_first, suite_test,
     else:
         config_override('resume.unstarted_first', True)
     [resumed_test] = get_tests_from_previous_session(result.session.id)
-    assert resumed_test.function_name == address_in_file(suite_test)
+    assert resumed_test.address_in_file == address_in_file(suite_test)
 
 @pytest.mark.parametrize('failed_only', [True, False])
 def test_failed_only_or_unstarted_first(suite, failed_only, config_override):
@@ -148,4 +148,4 @@ def test_resuming_interrupted_session(suite):
     results = suite.run(expect_interruption=True)
     resumed = get_tests_from_previous_session(results.session.id)
     assert len(resumed) == len(suite)
-    assert set(test.function_name for test in resumed) == set(address_in_file(test) for test in suite)
+    assert set(test.address_in_file for test in resumed) == set(address_in_file(test) for test in suite)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The slash fails to collect the class based test on rerun or resume. when saving test for resume it saves only the function name. While collecting test it compares with the address in file.
```
    def _iter_test_resume(self, resume_state):
        for test in self._iter_path(resume_state.file_name):
            if resume_state.function_name == test.__slash__.address_in_file:
                if resume_state.variation:
                    if not resume_state.variation == test.get_variation().id:
                        continue
                yield test
```

## Solution
Instead of function name saved the address in file property in ResumeState(function_name = address_in_file)

## Motivation and Context
#948 

## How Has This Been Tested?
```
slash resume random-previous session-id
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have modified tests to cover my changes.
- [x] All new and existing tests passed.
