### PR TITLE
Convert float and integer test details to strings in xunit output files

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ Changelog
 * :feature:`598` Drop support for python version < 3.6
 * :feature:`-` Added support for tagging test parameterization values
 * :feature:`-` Added a plugin which provides links to test logs which have been archived by a CI system
+* :bug:`-` Corrected behaviour of float and int test details in xunit output
 * :release:`1.8.0 <03-07-2019>`
 * :feature:`945` Drop support for deprecated arguments of ``add_cleanup``
 * :feature:`452` Drop support for old-style assertions

--- a/slash/plugins/builtin/xunit.py
+++ b/slash/plugins/builtin/xunit.py
@@ -53,6 +53,8 @@ class Plugin(PluginInterface):
         r = E(tag, {'name': name})
         if isinstance(value, (dict, tuple, list)):
             r = self._build_xml(r, value)
+        elif isinstance(value, (float, int)):
+            r.attrib['value'] = str(value)
         else:
             r.attrib['value'] = value
         return r

--- a/tests/test_xunit_plugin.py
+++ b/tests/test_xunit_plugin.py
@@ -77,7 +77,7 @@ def _get_testcase_xml(suite_test, filename):
     return match[0]
 
 
-@pytest.fixture(params=['set', 'append', 'complex'])
+@pytest.fixture(params=['set', 'append', 'complex', 'float', 'int'])
 def details(request, result):
 
     if request.param == 'set':
@@ -92,6 +92,14 @@ def details(request, result):
         result.details.append('detail1', 'value1')
         result.details.append(
             'detail1', {'complex': ['value2', 'value3']})
+
+    if request.param == 'float':
+        result.details.append('detail1', 12.3456)
+        result.details.append('detail1', {'complex': [9.7531]})
+
+    if request.param == 'int':
+        result.details.append('detail1', 1)
+        result.details.append('detail1', {'complex': [2]})
 
     return result.details.all()
 


### PR DESCRIPTION
This changeset adds conversion of float and integer test detail values to strings when writing xunit output, allowing tests which store float and integer test details to also generate xunit output.