### PR TITLE
support 'success_only_cleanup' yield fixture

### DIFF
--- a/slash/core/fixtures/utils.py
+++ b/slash/core/fixtures/utils.py
@@ -128,13 +128,15 @@ def yield_fixture(func=None, **kw):
     if func is None:
         return functools.partial(yield_fixture, **kw)
 
+    success_only_cleanup = kw.pop('success_only_cleanup', False)
+
     func = _ensure_fixture_info(func=func, **kw)
 
     @wraps(func)
     def new_func(**kwargs):
         f = func(**kwargs)
         value = next(f)
-        @context.fixture.add_cleanup
+        @context.fixture.add_cleanup(success_only_cleanup=success_only_cleanup)
         def cleanup(): # pylint: disable=unused-variable
             try:
                 next(f)


### PR DESCRIPTION
given success_only_cleanup=True, a yield_fixture will not call the 'exit' section
for the fixture if the test failed. this is useful when the cleanup can make it
difficult to troubleshoot/debug the failed test.