### PR TITLE
make 'TracebackProxy' compatible with 'inspect', which checks for types.TracebackType

### DIFF
--- a/slash/utils/traceback_proxy.py
+++ b/slash/utils/traceback_proxy.py
@@ -148,6 +148,9 @@ else:
                 tb = sys.exc_info()[2]
             return tb
 
+        @property
+        def __class__(self):
+            return types.TracebackType
 
     def create_traceback_proxy(tb=None, frame_correction=0):
         """


### PR DESCRIPTION
An attempt to use ipython's post-mortem code with `--pdb` failed deep inside, when ipython called on `inspect.getinnerframes`, which eventually failed on `inspect.getframeinfo`. The latter checks `if istraceback(frame)`, and falls into the wrong code path since `frame` is a TracebackProxy`