### PR TITLE
Unittests log tasks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ testing =
     coveralls
     munch
     pytest
-    pytest-catchlog
     pytest-cov
     pytest-timeout
     pyforge

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,11 @@ def no_user_config(request):
     def cleanup():  # pylint: disable=unused-variable
         os.rmdir(tmpdir)
 
+@pytest.fixture(autouse=True)
+def logbook_console_handler(request):
+    handler = logbook.StderrHandler(level=logbook.TRACE)
+    handler.push_application()
+    request.addfinalizer(handler.pop_application)
 
 @pytest.fixture
 def no_plugins(request):


### PR DESCRIPTION
* Remove pytest-catchlog dependency (it was merged into pytest core and now emits warning)
* Add stderr logbook handler to unittests