### PR TITLE
modified iter_suite_file_paths to get the test path as relative if the path is provided relative in the suite file

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,5 +1,6 @@
 Changelog
 =========
+* :bug:`-` Fix iter_suite_file_paths to get test path of the tests as relative if relative path is provided in suite file
 * :bug:`899 major` Fix slash.exclude decorator for fixtures
 * :release:`1.10.0 <21-04-2020>`
 * :bug:`1013 major` Allow slash.use_fixtures application on other fixtures

--- a/slash/utils/suite_files.py
+++ b/slash/utils/suite_files.py
@@ -9,6 +9,7 @@ SuiteEntry = namedtuple('SuiteEntry', 'path, matcher, repeat')
 def iter_suite_file_paths(suite_files):
     for filename in suite_files:
 
+        dirname = os.path.abspath(os.path.dirname(filename))
         with open(filename) as suite_file:
             for path in suite_file:
                 path = path.strip()
@@ -17,6 +18,9 @@ def iter_suite_file_paths(suite_files):
 
                 suite_entry = _parse_path_filter_and_repeat(path)
                 path = suite_entry.path
+
+                if not os.path.isabs(path):
+                    path = os.path.relpath(os.path.join(dirname, path))
 
                 if not path.endswith('.py') and '.py:' not in path and not os.path.isdir(path):
                     for p, other_filter in iter_suite_file_paths([path]):

--- a/slash/utils/suite_files.py
+++ b/slash/utils/suite_files.py
@@ -9,7 +9,6 @@ SuiteEntry = namedtuple('SuiteEntry', 'path, matcher, repeat')
 def iter_suite_file_paths(suite_files):
     for filename in suite_files:
 
-        dirname = os.path.abspath(os.path.dirname(filename))
         with open(filename) as suite_file:
             for path in suite_file:
                 path = path.strip()
@@ -18,9 +17,6 @@ def iter_suite_file_paths(suite_files):
 
                 suite_entry = _parse_path_filter_and_repeat(path)
                 path = suite_entry.path
-
-                if not os.path.isabs(path):
-                    path = os.path.abspath(os.path.join(dirname, path))
 
                 if not path.endswith('.py') and '.py:' not in path and not os.path.isdir(path):
                     for p, other_filter in iter_suite_file_paths([path]):

--- a/tests/test_suite_files.py
+++ b/tests/test_suite_files.py
@@ -24,7 +24,7 @@ def test_iter_suite_paths_files_relpath(filename, paths):
             f.write(relpath)
             f.write('\n')
 
-    assert [p for p, _ in suite_files.iter_suite_file_paths([filename])] == [os.path.relpath(p) for p in paths]
+    assert [os.path.abspath(p) for p, _ in suite_files.iter_suite_file_paths([filename])] == [p for p in paths]
 
 
 def test_suite_files(suite, suite_test, suite_file):  # pylint: disable=unused-argument

--- a/tests/test_suite_files.py
+++ b/tests/test_suite_files.py
@@ -24,7 +24,7 @@ def test_iter_suite_paths_files_relpath(filename, paths):
             f.write(relpath)
             f.write('\n')
 
-    assert [os.path.abspath(p) for p, _ in suite_files.iter_suite_file_paths([filename])] == [p for p in paths]
+    assert [os.path.abspath(p) for p, _ in suite_files.iter_suite_file_paths([filename])] == [os.path.abspath(p) for p in paths]
 
 
 def test_suite_files(suite, suite_test, suite_file):  # pylint: disable=unused-argument

--- a/tests/test_suite_files.py
+++ b/tests/test_suite_files.py
@@ -24,7 +24,7 @@ def test_iter_suite_paths_files_relpath(filename, paths):
             f.write(relpath)
             f.write('\n')
 
-    assert [p for p, _ in suite_files.iter_suite_file_paths([filename])] == [os.path.abspath(p) for p in paths]
+    assert [p for p, _ in suite_files.iter_suite_file_paths([filename])] == [os.path.relpath(p) for p in paths]
 
 
 def test_suite_files(suite, suite_test, suite_file):  # pylint: disable=unused-argument


### PR DESCRIPTION

## Description
Slash creates test path and test address based on how it is invoked. when the test path provided is relative then the test path and address of a test will be relative. 
```
slash list tests\test_script.py
``` 
If the path is provided as absolute then the test_path and address will be absolute.
```
slash list C:\package\tests\test_script.py
```

But when slash list or slash run is invoked with help of suite file the test path and test address of the test collected is always absolute irrespective of path provided in suite file.


## Solution
modified the iter_suite_file_paths method to provide relative path when relative path is provided and absolute path when absolute path is provided in suite_file
