### PR TITLE
Fix tag param for class test

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,5 +1,6 @@
 Changelog
 =========
+* :bug:`_` Fix to filter class based test based on the tagging in parameter
 * :bug:`899 major` Fix slash.exclude decorator for fixtures
 * :release:`1.10.0 <21-04-2020>`
 * :bug:`1013 major` Allow slash.use_fixtures application on other fixtures

--- a/slash/core/test.py
+++ b/slash/core/test.py
@@ -74,7 +74,9 @@ class Test(RunnableTest):
         return getattr(self, self._test_method_name)
 
     def get_tags(self):
-        test_tags = get_tags(type(self)) + get_tags(getattr(type(self), self._test_method_name))
+        test_tags = (get_tags(type(self))
+                     + get_tags(getattr(type(self), self._test_method_name))
+                     + self.get_variation().tags)
         if nofixtures.is_marked(self.get_test_function()):
             return test_tags
         return test_tags + self._get_fixture_tags()

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -150,6 +150,25 @@ def test_fixture_and_test_overrides(suite_builder):
 
     suite_builder.build().run().assert_session_error("Conflicting tag")
 
+
+def test_tagging_parameter(suite_builder):
+    # pylint: disable=unused-variable
+    @suite_builder.first_file.add_code
+    def __code__():
+        import slash  # pylint: disable=redefined-outer-name, reimported
+
+        class TaggedParams(slash.Test):
+            @slash.tag("unit_test")
+            @slash.parametrize("tag_name",
+                               ["tag_1" // slash.param(tags="tag_1"),
+                                "tag_2" // slash.tag("tag_2")])
+            def test_1(self, tag_name):
+                assert set(slash.context.test.get_tags()) == \
+                       {"unit_test", tag_name}
+
+    suite_builder.build().run().assert_success(2)
+
+
 # more tags in test_pattern_matching.py
 
 _tagging_strategies = []

--- a/tests/test_test_parameters.py
+++ b/tests/test_test_parameters.py
@@ -211,10 +211,11 @@ def test_parameterization_filtering(suite_builder):
 
 
 def test_parameterization_filtering_test_class_tests(suite_builder):
-    # pylint: disable=no-member, protected-access, undefined-variable,unused-variable, reimported, redefined-outer-name
+    # pylint: disable=no-member, undefined-variable, unused-variable
     @suite_builder.first_file.add_code
     def __code__():
-        import slash
+        import slash  # pylint: disable=redefined-outer-name, reimported
+
         class TaggedParams(slash.Test):
             @slash.parametrize('x', [
                 500 // slash.param(tags=["regression", "ultra"]),
@@ -230,12 +231,12 @@ def test_parameterization_filtering_test_class_tests(suite_builder):
             def test_1(self, x, y, z):
                 slash.context.result.data['params'] = (x, y, z)
 
-    suite_builder.build().run('-k', 'tag:regression=long and not tag:sanity').assert_success(4).with_data([
-        {'params': (500, '100', True)},
-        {'params': (500, '100', False)},
-        {'params': (50, '100', True)},
-        {'params': (50, '100', False)},
-    ])
+    suite_builder.build().run(
+        '-k', 'tag:regression=long and not tag:sanity'
+    ).assert_success(4).with_data(
+        [{'params': (500, '100', True)}, {'params': (500, '100', False)},
+         {'params': (50, '100', True)}, {'params': (50, '100', False)}]
+    )
 
 
 def _set(param, value):

--- a/tests/test_test_parameters.py
+++ b/tests/test_test_parameters.py
@@ -210,6 +210,34 @@ def test_parameterization_filtering(suite_builder):
     ])
 
 
+def test_parameterization_filtering_test_class_tests(suite_builder):
+    # pylint: disable=no-member, protected-access, undefined-variable,unused-variable, reimported, redefined-outer-name
+    @suite_builder.first_file.add_code
+    def __code__():
+        import slash
+        class TaggedParams(slash.Test):
+            @slash.parametrize('x', [
+                500 // slash.param(tags=["regression", "ultra"]),
+                50 // slash.param(tags="regression"),
+                5 // slash.param(tags="sanity"),
+            ])
+            @slash.parametrize('y', [
+                '100' // slash.tag("regression", "long"),
+                '10' // slash.tag("regression", "short"),
+                '1' // slash.tag("sanity"),
+            ])
+            @slash.parametrize('z', [True, False])
+            def test_1(self, x, y, z):
+                slash.context.result.data['params'] = (x, y, z)
+
+    suite_builder.build().run('-k', 'tag:regression=long and not tag:sanity').assert_success(4).with_data([
+        {'params': (500, '100', True)},
+        {'params': (500, '100', False)},
+        {'params': (50, '100', True)},
+        {'params': (50, '100', False)},
+    ])
+
+
 def _set(param, value):
     data = slash.session.results.current.data
     assert param not in data


### PR DESCRIPTION
## Description
The New feature from slash 1.9.0 lets the tester to add tag to the test params. This tagging of test param is not working for class based test. Unable to filter the tests that are tagged in params of class based tests.

Sample code
```
class SampleTest(slash.Test):
    @slash.tag("settings")
    @slash.parametrize(
        "choose_door_keypad", ["new" // slash.param("T1", tags="bt-sanity"),
                               "existing" // slash.param("T2")])
    def test_5(self, choose_door_keypad):
        print("testing 5:" + choose_door_keypad)
``` 
In the above sample code tags are provided to param of class based test. when trying to filter the test with the tag. slash is unable to filter it.

```
slash run -k tag:bt-sanity <path-of-the-script>
```


## Solution
fetched the tags of params while getting the tags in get_tags method in class Test
