### PR TITLE
Modified xunit plugin not to report the not run tests

### DIFF
--- a/slash/plugins/builtin/xunit.py
+++ b/slash/plugins/builtin/xunit.py
@@ -88,10 +88,18 @@ class Plugin(PluginInterface):
             "tests": str(context.session.results.get_num_results()),
             "errors": str(context.session.results.get_num_errors()),
             "failures": str(context.session.results.get_num_failures()),
-            "skipped": str(context.session.results.get_num_skipped()),
+            "skipped": str(
+                context.session.results.get_num_skipped(include_not_run=False)
+            ),
         })
         self._add_errors(e, context.session.results.global_result)
-        for result in context.session.results.iter_test_results():
+        run_test_results = filter(
+            lambda result: not result.is_not_run(),
+            context.session.results.iter_test_results()
+        )
+
+        for result in run_test_results:
+
             test = E("testcase", {
                 "name": result.test_metadata.address,
                 "classname": result.test_metadata.class_name or '',

--- a/slash/plugins/builtin/xunit.py
+++ b/slash/plugins/builtin/xunit.py
@@ -94,7 +94,7 @@ class Plugin(PluginInterface):
         })
         self._add_errors(e, context.session.results.global_result)
         run_test_results = filter(
-            lambda result: not result.is_not_run(),
+            lambda result: result.is_started(),
             context.session.results.iter_test_results()
         )
 


### PR DESCRIPTION
## Description
The passed test and the not run test looks the same in the xunit XML report.  
When xunit xml reports are parsed through  [xunit](https://plugins.jenkins.io/xunit/) plugin in the jenkins. The Jenkins reports even the not run as passed tests. 

Following are the link which I referred for the Junit XML schema since the slash xunit report is similar to Junit xml report
- https://llg.cubic.org/docs/junit/
- https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd
- https://github.com/junit-team/junit5/blob/main/platform-tests/src/test/resources/jenkins-junit.xsd
- https://help.catchsoftware.com/display/ET/JUnit+Format

On the XML report Schema in the Junit xml report no where it is mentioned to report the not run test results in the report.

## Solution:
modified xunit report plugin to report only the run tests in xml report.
