### PR TITLE
python 3.6 and ipython 7.17.0 are not compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ pyparsing
 vintage>=0.4.0
 brotli
 IPython==1.2.1; implementation_name=='pypy'
-IPython<7.17.0; implementation_name!='pypy' and python_version<='3.6'
-IPython; implementation_name!='pypy' and python_version>'3.6'
+IPython<7.17.0; implementation_name!='pypy' and python_version<'3.6'
+IPython; implementation_name!='pypy' and python_version>='3.6'


### PR DESCRIPTION
Presumably more or less no-one is using the exact python version 3.6 so this doesn't really matter, but you have a sort of out-by-one error here.