### PR TITLE
Make python_requires PEP 440 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,6 @@ from setuptools import setup
 setup(
     setup_requires=['pbr>=3.0', 'setuptools>=17.1'],
     pbr=True,
-    python_requires=">=3.6.*",
+    python_requires=">=3.6",
     long_description_content_type='text/markdown; charset=UTF-8',
 )


### PR DESCRIPTION
Recent changes to setuptools (https://github.com/pypa/setuptools/issues/3790) released in version 67.0.0 make the `python_requires` check more strick and **prevents the installation of Slash.**