### PR TITLE
Add flag for resuming session without skipped tests

### DIFF
--- a/doc/slash_run.rst
+++ b/doc/slash_run.rst
@@ -109,7 +109,7 @@ When you run a session that fails, Slash automatically saves the tests intended 
 
   $ slash resume -vv <session id>
 
-This command receives all flags which can be passed to ``slash run``, but receives an id of a previously run session for resuming. All unsuccessful tests are then rerun in a new session. You can control whether to attempt failed tests first or planned (not started) tests through the ``--failed-first`` and ``--unstarted-first`` command-line flags respectively.
+This command receives all flags which can be passed to ``slash run``, but receives an id of a previously run session for resuming. All unsuccessful tests are then rerun in a new session. You can control whether to attempt failed tests first or planned (not started) tests through the ``--failed-first`` and ``--unstarted-first`` command-line flags respectively. You can also control which tests to resume through the ``--failed-only``, ``--unstarted-only``, and ``--no-skipped`` command-line flags. You can use combinations of the latter two but not with the first (failed-ony).
 
 
 Rerunning Previous Sessions

--- a/slash/conf.py
+++ b/slash/conf.py
@@ -123,6 +123,7 @@ config = Config({
         "unstarted_first": False // Doc("Run unstarted tests of previous session before all others") // Cmdline(on='--unstarted-first', metavar="UNSTARTED_FIRST"),
         "failed_only": False // Doc("Run only failed tests of previous session") // Cmdline(on='--failed-only', metavar="FAILED_ONLY"),
         "unstarted_only": False // Doc("Run only unstarted tests of previous session") // Cmdline(on='--unstarted-only', metavar="UNSTARTED_ONLY"),
+        "unstarted_only_without_skipped": False // Doc("Run only unstarted tests of previous session without skipped tests") // Cmdline(on='--unstarted-only-without-skipped', metavar="UNSTARTED_ONLY_WITHOUT_SKIPPED"),
         "state_retention_days": 10 // Doc("Number of days to keep session entries for resuming session")
     },
     "tmux": {

--- a/slash/conf.py
+++ b/slash/conf.py
@@ -123,7 +123,7 @@ config = Config({
         "unstarted_first": False // Doc("Run unstarted tests of previous session before all others") // Cmdline(on='--unstarted-first', metavar="UNSTARTED_FIRST"),
         "failed_only": False // Doc("Run only failed tests of previous session") // Cmdline(on='--failed-only', metavar="FAILED_ONLY"),
         "unstarted_only": False // Doc("Run only unstarted tests of previous session") // Cmdline(on='--unstarted-only', metavar="UNSTARTED_ONLY"),
-        "unstarted_only_without_skipped": False // Doc("Run only unstarted tests of previous session without skipped tests") // Cmdline(on='--unstarted-only-without-skipped', metavar="UNSTARTED_ONLY_WITHOUT_SKIPPED"),
+        "no_skipped": False // Doc("Run tests of previous session without skipped tests") // Cmdline(on='--no-skipped', metavar="NO_SKIPPED"),
         "state_retention_days": 10 // Doc("Number of days to keep session entries for resuming session")
     },
     "tmux": {

--- a/slash/resuming.py
+++ b/slash/resuming.py
@@ -44,6 +44,7 @@ class ResumeTestStatus(object):
     PLANNED = 'planned'
     SUCCESS = 'success'
     FAILED = 'failed'
+    SKIPPED = 'skipped'
 
 
 class ResumedTestData(object):
@@ -110,6 +111,8 @@ def save_resume_state(session_result, collected_tests):
         test_to_resume.variation = str(metadata.variation.id) if metadata.variation else None
         if result.is_success_finished():
             test_to_resume.status = ResumeTestStatus.SUCCESS
+        elif (not result.is_started()) and result.is_skip():
+            test_to_resume.status = ResumeTestStatus.SKIPPED
         elif not result.is_started() or result.is_skip():
             test_to_resume.status = ResumeTestStatus.PLANNED
         else:
@@ -144,6 +147,8 @@ def _get_resume_status_from_backslash_status(backslash_status):
         return ResumeTestStatus.FAILED
     elif backslash_status in ['SUCCESS']:
         return ResumeTestStatus.SUCCESS
+    elif backslash_status in ['SKIPPED']:
+        return ResumeTestStatus.SKIPPED
     else:
         return ResumeTestStatus.PLANNED
 
@@ -179,10 +184,18 @@ def get_tests_locally(session_id):
 
 def _filter_tests(tests, get_successful_tests):
     unstarted_only, failed_only = config.root.resume.unstarted_only, config.root.resume.failed_only
+    unstarted_only_without_skipped = config.root.resume.unstarted_only_without_skipped
     if unstarted_only and failed_only:
         raise CannotResume("Got both unstarted_only and failed_only, cannot resume")
+    if unstarted_only_without_skipped and failed_only:
+        raise CannotResume("Got both unstarted_only_without_skipped and failed_only, cannot resume")
+    if unstarted_only and unstarted_only_without_skipped:
+        raise CannotResume("Got both unstarted_only and unstarted_only_without_skipped, cannot resume")
     filtered_status = [ResumeTestStatus.SUCCESS] if get_successful_tests else []
     if unstarted_only:
+        filtered_status.append(ResumeTestStatus.PLANNED)
+        filtered_status.append(ResumeTestStatus.SKIPPED)
+    elif unstarted_only_without_skipped:
         filtered_status.append(ResumeTestStatus.PLANNED)
     elif failed_only:
         filtered_status.append(ResumeTestStatus.FAILED)


### PR DESCRIPTION
Adding `unstarted-only-without-skipped` option when resuming.