### PR TITLE
Remove xunit testcase classname attribute for test functions

### DIFF
--- a/slash/plugins/builtin/xunit.py
+++ b/slash/plugins/builtin/xunit.py
@@ -102,9 +102,12 @@ class Plugin(PluginInterface):
 
             test = E("testcase", {
                 "name": result.test_metadata.address,
-                "classname": result.test_metadata.class_name or '',
                 "time": str(result.get_duration().total_seconds())
             })
+
+            if result.test_metadata.class_name:
+                test.attrib["classname"] = result.test_metadata.class_name
+
             self._add_errors(test, result)
 
             for skip in result.get_skips():


### PR DESCRIPTION
Empty string` classname` is causing issues in some parsers and here the `classname` is really `None` and not `""`