### PR TITLE
Simplify dependency specification for ipython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,7 @@ dependencies = [
     "pyparsing",
     "vintage>=0.4.0",
     "brotli",
-    "IPython==1.2.1; implementation_name=='pypy'",
-    "IPython<7.17.0; implementation_name!='pypy' and python_version<='3.6'",
-    "IPython; implementation_name!='pypy' and python_version>'3.6'",
+    "IPython>=1.2.1",
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
I have had many issues with resolving dependencies in projects that use `poetry` or `pdm`. `ipython` 1.2.1 is used when installing slash in Python 3.7+ on Windows/Ubuntu/macOS. The changes proposed in this PR should preserve the current behaviour when using `pypy`, while allowing `cpython` implementations to use more recent versions of `ipython`.