### PR TITLE
Relax dessert version requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "arrow",
     "colorama",
     "confetti>=2.5.3",
-    "dessert~=1.4.7",
+    "dessert==1.*",
     "emport~=1.3.1",
     "gossip>=2.3.0",
     "Jinja2",


### PR DESCRIPTION
Relax dessert version requirements to allow version 1.5.0 and future  API compatible versions.