### PR TITLE
Fix the workflow to run on static version of Ubuntu

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]


### PR DESCRIPTION
Change the runs-on from ubuntu-latest to ubuntu-22.04 to avoid picking up ubuntu-24.04 (current ubuntu-latest).

ubuntu-24.04 do not have Python 3.7 and is breaking the current matrix.

Future improvement would be to include the `runs-on` in the matrix itself.